### PR TITLE
feat: Add dark mode support

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -39,7 +39,7 @@ section {
 }
 
 .mybg {
-  @apply bg-gradient-to-br from-blue-50 via-indigo-50 to-purple-50
+  @apply bg-gradient-to-br from-blue-50 via-indigo-50 to-purple-50 dark:from-slate-800 dark:via-slate-900 dark:to-black;
 }
 .ptitle {
   @apply text-4xl mb-6 font-semibold text-gray-800 text-center;

--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -1,43 +1,49 @@
 <template>
-  <header class="relative py-2 border-b border-gray-300 bg-white">
+  <header class="relative py-2 border-b border-gray-300 bg-white dark:bg-slate-900 dark:border-gray-700">
     <div class="sektion !my-0 flex items-center justify-between">
       <NuxtLink :to="localePath('/')" class="flex items-center justify-center hover:opacity-80 transition-opacity duration-100">
         <div class="w-10 h-10 flex items-center justify-center mr-3">
           <img src="/aat.svg" alt="AAT Logo" class="w-10 h-10" />
         </div>
         <div class="flex flex-col items-start justify-start">
-          <p class="text-lg font-semibold text-gray-800">{{ $t('header.title') }}</p>
-          <div class="text-xs text-gray-500 -mt-1">{{ $t('header.subtitle') }}</div>
+          <p class="text-lg font-semibold text-gray-800 dark:text-gray-200">{{ $t('header.title') }}</p>
+          <div class="text-xs text-gray-500 dark:text-gray-400 -mt-1">{{ $t('header.subtitle') }}</div>
         </div>
       </NuxtLink>
       
       <div class="flex items-center space-x-4">
         <nav class="hidden md:flex items-center space-x-4">
-          <NuxtLink :to="localePath('/') + '#techniques'" class="text-sm text-gray-600 hover:text-gray-800 hover:underline">{{ $t('navigation.techniques') }}</NuxtLink>
-          <NuxtLink :to="localePath('/') + '#about'" class="text-sm text-gray-600 hover:text-gray-800 hover:underline">{{ $t('navigation.about') }}</NuxtLink>
-          <NuxtLink :to="localePath('/') + '#resources'" class="text-sm text-gray-600 hover:text-gray-800 hover:underline">{{ $t('navigation.resources') }}</NuxtLink>
+          <NuxtLink :to="localePath('/') + '#techniques'" class="text-sm text-gray-600 hover:text-gray-800 hover:underline dark:text-gray-300 dark:hover:text-gray-100">{{ $t('navigation.techniques') }}</NuxtLink>
+          <NuxtLink :to="localePath('/') + '#about'" class="text-sm text-gray-600 hover:text-gray-800 hover:underline dark:text-gray-300 dark:hover:text-gray-100">{{ $t('navigation.about') }}</NuxtLink>
+          <NuxtLink :to="localePath('/') + '#resources'" class="text-sm text-gray-600 hover:text-gray-800 hover:underline dark:text-gray-300 dark:hover:text-gray-100">{{ $t('navigation.resources') }}</NuxtLink>
         </nav>
         
+        <button @click="toggleTheme" class="flex items-center text-sm px-2 py-1 border border-gray-300 rounded text-gray-700 hover:bg-gray-50 transition-colors duration-200 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800">
+          <Icon v-if="colorMode.preference === 'light'" name="ph:sun" class="text-base" />
+          <Icon v-else-if="colorMode.preference === 'dark'" name="ph:moon" class="text-base" />
+          <Icon v-else name="ph:desktop" class="text-base" />
+        </button>
+
         <a 
           href="https://github.com/alvinunreal/anxiety-aid-tools" 
           target="_blank"
-          class="flex items-center text-sm px-2 py-1 border border-gray-300 rounded text-gray-700 hover:bg-gray-50 transition-colors duration-200"
+          class="flex items-center text-sm px-2 py-1 border border-gray-300 rounded text-gray-700 hover:bg-gray-50 transition-colors duration-200 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
         >
           <Icon name="mdi:github" class="text-base mr-1" />
           {{ $t('navigation.github') }}
         </a>
         
         <button class="md:hidden flex items-center justify-center" @click="mobileMenuOpen = !mobileMenuOpen">
-          <Icon name="ph:list" class="text-2xl text-gray-700" />
+          <Icon name="ph:list" class="text-2xl text-gray-700 dark:text-gray-300" />
         </button>
       </div>
     </div>
     
-    <div v-if="mobileMenuOpen" class="absolute top-full left-0 right-0 md:hidden border-t border-gray-300 bg-white z-50">
+    <div v-if="mobileMenuOpen" class="absolute top-full left-0 right-0 md:hidden border-t border-gray-300 bg-white z-50 dark:bg-slate-900 dark:border-gray-700">
       <nav class="sektion !my-0 py-4 flex flex-col space-y-1">
-        <NuxtLink :to="localePath('/') + '#techniques'" class="text-sm text-gray-600 hover:text-gray-800 hover:underline py-3 px-2 -mx-2 rounded">{{ $t('navigation.techniques') }}</NuxtLink>
-        <NuxtLink :to="localePath('/') + '#about'" class="text-sm text-gray-600 hover:text-gray-800 hover:underline py-3 px-2 -mx-2 rounded">{{ $t('navigation.about') }}</NuxtLink>
-        <NuxtLink :to="localePath('/') + '#resources'" class="text-sm text-gray-600 hover:text-gray-800 hover:underline py-3 px-2 -mx-2 rounded">{{ $t('navigation.resources') }}</NuxtLink>
+        <NuxtLink :to="localePath('/') + '#techniques'" class="text-sm text-gray-600 hover:text-gray-800 hover:underline py-3 px-2 -mx-2 rounded dark:text-gray-300 dark:hover:text-gray-100">{{ $t('navigation.techniques') }}</NuxtLink>
+        <NuxtLink :to="localePath('/') + '#about'" class="text-sm text-gray-600 hover:text-gray-800 hover:underline py-3 px-2 -mx-2 rounded dark:text-gray-300 dark:hover:text-gray-100">{{ $t('navigation.about') }}</NuxtLink>
+        <NuxtLink :to="localePath('/') + '#resources'" class="text-sm text-gray-600 hover:text-gray-800 hover:underline py-3 px-2 -mx-2 rounded dark:text-gray-300 dark:hover:text-gray-100">{{ $t('navigation.resources') }}</NuxtLink>
       </nav>
     </div>
   </header>
@@ -46,4 +52,13 @@
 <script setup>
 const localePath = useLocalePath()
 const mobileMenuOpen = ref(false)
+const colorMode = useColorMode()
+
+const themes = ['light', 'dark', 'system']
+
+function toggleTheme() {
+  const currentThemeIndex = themes.indexOf(colorMode.preference)
+  const nextThemeIndex = (currentThemeIndex + 1) % themes.length
+  colorMode.preference = themes[nextThemeIndex]
+}
 </script>

--- a/components/RelatedTechniques.vue
+++ b/components/RelatedTechniques.vue
@@ -1,8 +1,8 @@
 <template>
   <section class="py-12">
     <div class="text-center">
-      <h2 class="mb-6 text-4xl font-semibold text-gray-800">{{ $t('relatedTechniques.title') }}</h2>
-      <p class="mb-8 text-gray-600">
+      <h2 class="mb-6 text-4xl font-semibold text-gray-800 dark:text-gray-200">{{ $t('relatedTechniques.title') }}</h2>
+      <p class="mb-8 text-gray-600 dark:text-gray-400">
         {{ $t('relatedTechniques.description') }}
       </p>
     </div>
@@ -11,16 +11,16 @@
         v-for="technique in relatedTechniques"
         :key="technique.id"
         :to="getLocalizedTechniqueRoute(technique)"
-        class="group flex flex-col gap-3 border border-gray-200 bg-gray-50 p-6 transition-colors duration-100 hover:bg-gray-100"
+        class="group flex flex-col gap-3 border border-gray-200 bg-gray-50 p-6 transition-colors duration-100 hover:bg-gray-100 dark:bg-slate-800/20 dark:border-slate-700 dark:hover:bg-slate-700/20"
       >
         <div class="flex items-center gap-3">
           <Icon :name="technique.icon" class="text-2xl" :class="technique.iconColor" />
-          <p class="flex-1 font-semibold text-gray-800">
+          <p class="flex-1 font-semibold text-gray-800 dark:text-gray-200">
             {{ $t(`techniques.${technique.id}.name`) }}
           </p>
           <Icon name="ph:arrow-right" class="text-sm text-gray-500" />
         </div>
-        <p class="text-sm text-gray-600">
+        <p class="text-sm text-gray-600 dark:text-gray-400">
           {{ $t(`techniques.${technique.id}.short_description`) }}
         </p>
       </NuxtLink>

--- a/components/SectionHeader.vue
+++ b/components/SectionHeader.vue
@@ -3,7 +3,7 @@
     <div class="flex h-10 w-10 sm:h-8 sm:w-8 items-center justify-center flex-shrink-0" :class="iconBgClass">
       <Icon :name="icon" class="text-2xl sm:text-lg" :class="iconClass" />
     </div>
-    <h2 class="text-lg font-semibold text-gray-800">
+    <h2 class="text-lg font-semibold text-gray-800 dark:text-gray-200">
       <slot />
     </h2>
   </div>
@@ -22,6 +22,6 @@ const props = defineProps({
   }
 })
 
-const iconBgClass = computed(() => `bg-${props.color}-100`)
-const iconClass = computed(() => `text-${props.color}-600`)
+const iconBgClass = computed(() => `bg-${props.color}-100 dark:bg-${props.color}-900/10`)
+const iconClass = computed(() => `text-${props.color}-600 dark:text-${props.color}-400`)
 </script>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -36,7 +36,12 @@ export default defineNuxtConfig({
     "@nuxtjs/seo",
     "@nuxtjs/i18n",
     '@sentry/nuxt/module',
+    "@nuxtjs/color-mode",
   ],
+
+  colorMode: {
+    classSuffix: "",
+  },
 
   tailwindcss: {
     cssPath: "~/assets/css/tailwind.css",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@nuxt/eslint-config": "^1.3.1",
     "@nuxt/icon": "^1.12.0",
     "@nuxt/image": "1.10.0",
+    "@nuxtjs/color-mode": "^3.5.2",
     "@nuxtjs/device": "^3.2.4",
     "@nuxtjs/google-fonts": "^3.2.0",
     "@nuxtjs/tailwindcss": "^6.14.0",

--- a/pages/breathing.vue
+++ b/pages/breathing.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-gradient-to-br from-indigo-50 via-purple-50 to-blue-50 py-8">
+  <div class="min-h-screen bg-gradient-to-br from-indigo-50 via-purple-50 to-blue-50 py-8 dark:from-slate-800 dark:via-slate-900 dark:to-black">
     <Breadcrumb duration="2-3 min" />
 
     <!-- Exercise Component -->
@@ -8,41 +8,41 @@
     <!-- Educational Content -->
     <section>
       <!-- What happens in your body -->
-      <div class="border border-gray-200 bg-white/60 p-6">
+      <div class="border border-gray-200 bg-white/60 p-6 dark:bg-slate-800/20 dark:border-slate-700">
         <div>
           <SectionHeader icon="ph:brain" color="gray">
             {{ $t("breathing.education.whatHappens.title") }}
           </SectionHeader>
           <div class="px-1">
-            <p class="mb-3 text-sm leading-relaxed text-gray-700">
+            <p class="mb-3 text-sm leading-relaxed text-gray-700 dark:text-gray-400">
               {{ $t("breathing.education.whatHappens.description") }}
             </p>
-            <p class="mb-3 text-sm leading-relaxed text-gray-700">
+            <p class="mb-3 text-sm leading-relaxed text-gray-700 dark:text-gray-400">
               {{ $t("breathing.education.whatHappens.benefits") }}
             </p>
-            <p class="mb-3 text-sm leading-relaxed text-gray-700">
+            <p class="mb-3 text-sm leading-relaxed text-gray-700 dark:text-gray-400">
               {{ $t("breathing.education.whatHappens.practice") }}
             </p>
             <div class="mt-4 grid gap-4 md:grid-cols-2">
-              <div class="border border-gray-200 bg-white/60 p-3">
+              <div class="border border-gray-200 bg-white/60 p-3 dark:bg-slate-700/20 dark:border-slate-600">
                 <div class="mb-1 flex items-center">
                   <Icon name="ph:arrow-down" class="mr-2 text-cyan-600" />
-                  <span class="text-xs font-medium text-gray-800">{{
+                  <span class="text-xs font-medium text-gray-800 dark:text-gray-200">{{
                     $t("breathing.education.inhale.title")
                   }}</span>
                 </div>
-                <p class="text-xs text-gray-600">
+                <p class="text-xs text-gray-600 dark:text-gray-400">
                   {{ $t("breathing.education.inhale.description") }}
                 </p>
               </div>
-              <div class="border border-gray-200 bg-white/60 p-3">
+              <div class="border border-gray-200 bg-white/60 p-3 dark:bg-slate-700/20 dark:border-slate-600">
                 <div class="mb-1 flex items-center">
                   <Icon name="ph:arrow-up" class="mr-2 text-cyan-600" />
-                  <span class="text-xs font-medium text-gray-800">{{
+                  <span class="text-xs font-medium text-gray-800 dark:text-gray-200">{{
                     $t("breathing.education.exhale.title")
                   }}</span>
                 </div>
-                <p class="text-xs text-gray-600">
+                <p class="text-xs text-gray-600 dark:text-gray-400">
                   {{ $t("breathing.education.exhale.description") }}
                 </p>
               </div>
@@ -54,38 +54,38 @@
 
     <!-- Scientific Background -->
     <section>
-      <div class="border border-gray-200 bg-white/60 p-6">
+      <div class="border border-gray-200 bg-white/60 p-6 dark:bg-slate-800/20 dark:border-slate-700">
         <SectionHeader icon="ph:flask" color="purple">
           {{ $t("breathing.education.science.title") }}
         </SectionHeader>
         
         <div class="mb-4">
-          <p class="text-sm leading-relaxed text-gray-700" v-html="$t('breathing.education.science.description')"></p>
+          <p class="text-sm leading-relaxed text-gray-700 dark:text-gray-400" v-html="$t('breathing.education.science.description')"></p>
         </div>
 
         <div class="grid gap-4 md:grid-cols-3">
-          <div class="border border-purple-200 bg-purple-50 p-4">
+          <div class="border border-purple-200 bg-purple-50 p-4 dark:bg-purple-900/10 dark:border-purple-500/20">
             <div class="mb-2 flex items-center">
               <Icon name="ph:drop" class="mr-2 text-purple-600" />
-              <span class="text-sm font-medium text-gray-800">{{ $t("breathing.education.science.research.cortisol.title") }}</span>
+              <span class="text-sm font-medium text-gray-800 dark:text-gray-200">{{ $t("breathing.education.science.research.cortisol.title") }}</span>
             </div>
-            <p class="text-xs text-gray-600" v-html="$t('breathing.education.science.research.cortisol.description')"></p>
+            <p class="text-xs text-gray-600 dark:text-gray-400" v-html="$t('breathing.education.science.research.cortisol.description')"></p>
           </div>
           
-          <div class="border border-purple-200 bg-purple-50 p-4">
+          <div class="border border-purple-200 bg-purple-50 p-4 dark:bg-purple-900/10 dark:border-purple-500/20">
             <div class="mb-2 flex items-center">
               <Icon name="ph:heart" class="mr-2 text-purple-600" />
-              <span class="text-sm font-medium text-gray-800">{{ $t("breathing.education.science.research.anxiety.title") }}</span>
+              <span class="text-sm font-medium text-gray-800 dark:text-gray-200">{{ $t("breathing.education.science.research.anxiety.title") }}</span>
             </div>
-            <p class="text-xs text-gray-600" v-html="$t('breathing.education.science.research.anxiety.description')"></p>
+            <p class="text-xs text-gray-600 dark:text-gray-400" v-html="$t('breathing.education.science.research.anxiety.description')"></p>
           </div>
           
-          <div class="border border-purple-200 bg-purple-50 p-4">
+          <div class="border border-purple-200 bg-purple-50 p-4 dark:bg-purple-900/10 dark:border-purple-500/20">
             <div class="mb-2 flex items-center">
               <Icon name="ph:lightning" class="mr-2 text-purple-600" />
-              <span class="text-sm font-medium text-gray-800">{{ $t("breathing.education.science.research.vagal.title") }}</span>
+              <span class="text-sm font-medium text-gray-800 dark:text-gray-200">{{ $t("breathing.education.science.research.vagal.title") }}</span>
             </div>
-            <p class="text-xs text-gray-600" v-html="$t('breathing.education.science.research.vagal.description')"></p>
+            <p class="text-xs text-gray-600 dark:text-gray-400" v-html="$t('breathing.education.science.research.vagal.description')"></p>
           </div>
         </div>
       </div>
@@ -94,11 +94,11 @@
     <section>
       <div class="grid gap-8 md:grid-cols-2">
         <!-- When to Use -->
-        <div class="border border-gray-200 bg-white/60 p-6">
+        <div class="border border-gray-200 bg-white/60 p-6 dark:bg-slate-800/20 dark:border-slate-700">
           <SectionHeader icon="ph:calendar-check" color="blue">
             {{ $t("breathing.education.whenToPractice.title") }}
           </SectionHeader>
-          <ul class="space-y-3 text-sm text-gray-700">
+          <ul class="space-y-3 text-sm text-gray-700 dark:text-gray-400">
             <li class="flex items-start">
               <Icon name="ph:sun" class="mr-2 mt-0.5 flex-shrink-0 text-yellow-500" />
               <span>{{ $t("breathing.education.whenToPractice.items.0") }}</span>
@@ -119,11 +119,11 @@
         </div>
 
         <!-- What You'll Experience -->
-        <div class="border border-gray-200 bg-white/60 p-6">
+        <div class="border border-gray-200 bg-white/60 p-6 dark:bg-slate-800/20 dark:border-slate-700">
           <SectionHeader icon="ph:trend-up" color="green">
             {{ $t("breathing.education.whatYoullNotice.title") }}
           </SectionHeader>
-          <ul class="space-y-3 text-sm text-gray-700">
+          <ul class="space-y-3 text-sm text-gray-700 dark:text-gray-400">
             <li class="flex items-start">
               <Icon name="ph:timer-fill" class="mr-2 mt-0.5 flex-shrink-0 text-blue-400" />
               <span>{{ $t("breathing.education.whatYoullNotice.items.0") }}</span>
@@ -147,35 +147,35 @@
 
     <!-- Tips Section -->
     <section>
-      <div class="border border-indigo-200 bg-indigo-50 p-6">
+      <div class="border border-indigo-200 bg-indigo-50 p-6 dark:bg-indigo-900/10 dark:border-indigo-500/20">
         <div class="mb-4 text-center">
           <Icon name="ph:lightbulb" class="mx-auto mb-2 text-2xl text-indigo-600" />
-          <h2 class="font-semibold text-gray-800">
+          <h2 class="font-semibold text-gray-800 dark:text-gray-200">
             {{ $t("breathing.education.bestResults.title") }}
           </h2>
         </div>
         <div class="grid gap-4 text-sm md:grid-cols-3">
           <div class="text-center">
-            <div class="mb-1 font-medium text-indigo-600">
+            <div class="mb-1 font-medium text-indigo-600 dark:text-indigo-400">
               {{ $t("breathing.education.bestResults.posture.title") }}
             </div>
-            <p class="text-gray-600">
+            <p class="text-gray-600 dark:text-gray-400">
               {{ $t("breathing.education.bestResults.posture.description") }}
             </p>
           </div>
           <div class="text-center">
-            <div class="mb-1 font-medium text-indigo-600">
+            <div class="mb-1 font-medium text-indigo-600 dark:text-indigo-400">
               {{ $t("breathing.education.bestResults.environment.title") }}
             </div>
-            <p class="text-gray-600">
+            <p class="text-gray-600 dark:text-gray-400">
               {{ $t("breathing.education.bestResults.environment.description") }}
             </p>
           </div>
           <div class="text-center">
-            <div class="mb-1 font-medium text-indigo-600">
+            <div class="mb-1 font-medium text-indigo-600 dark:text-indigo-400">
               {{ $t("breathing.education.bestResults.consistency.title") }}
             </div>
-            <p class="text-gray-600">
+            <p class="text-gray-600 dark:text-gray-400">
               {{ $t("breathing.education.bestResults.consistency.description") }}
             </p>
           </div>

--- a/pages/grounding.vue
+++ b/pages/grounding.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-gradient-to-br from-green-50 via-emerald-50 to-teal-50 py-8">
+  <div class="min-h-screen bg-gradient-to-br from-green-50 via-emerald-50 to-teal-50 py-8 dark:from-slate-800 dark:via-slate-900 dark:to-black">
     <Breadcrumb duration="3-5 min" />
 
     <!-- Exercise Component -->
@@ -8,26 +8,26 @@
     <!-- Educational Content -->
     <!-- How It Works -->
     <section>
-      <div class="border border-gray-200 bg-white/60 p-6">
+      <div class="border border-gray-200 bg-white/60 p-6 dark:bg-slate-800/20 dark:border-slate-700">
         <SectionHeader icon="ph:brain" color="green">
           {{ $t("grounding.howItWorks.title") }}
         </SectionHeader>
         <div class="grid gap-6 md:grid-cols-2">
           <div>
-            <h3 class="mb-2 font-semibold text-gray-800">{{ $t("grounding.howItWorks.neurological.title") }}</h3>
-            <p class="mb-3 text-sm leading-relaxed text-gray-700">
+            <h3 class="mb-2 font-semibold text-gray-800 dark:text-gray-200">{{ $t("grounding.howItWorks.neurological.title") }}</h3>
+            <p class="mb-3 text-sm leading-relaxed text-gray-700 dark:text-gray-400">
               {{ $t("grounding.howItWorks.neurological.description") }}
             </p>
-            <p class="text-sm leading-relaxed text-gray-700">
+            <p class="text-sm leading-relaxed text-gray-700 dark:text-gray-400">
               {{ $t("grounding.howItWorks.neurological.awareness") }}
             </p>
           </div>
           <div>
-            <h3 class="mb-2 font-semibold text-gray-800">{{ $t("grounding.howItWorks.stability.title") }}</h3>
-            <p class="mb-3 text-sm leading-relaxed text-gray-700">
+            <h3 class="mb-2 font-semibold text-gray-800 dark:text-gray-200">{{ $t("grounding.howItWorks.stability.title") }}</h3>
+            <p class="mb-3 text-sm leading-relaxed text-gray-700 dark:text-gray-400">
               {{ $t("grounding.howItWorks.stability.description") }}
             </p>
-            <p class="text-sm leading-relaxed text-gray-700">
+            <p class="text-sm leading-relaxed text-gray-700 dark:text-gray-400">
               {{ $t("grounding.howItWorks.stability.grounding") }}
             </p>
           </div>
@@ -37,38 +37,38 @@
 
     <!-- Scientific Background -->
     <section>
-      <div class="border border-gray-200 bg-white/60 p-6">
+      <div class="border border-gray-200 bg-white/60 p-6 dark:bg-slate-800/20 dark:border-slate-700">
         <SectionHeader icon="ph:flask" color="purple">
           {{ $t("grounding.science.title") }}
         </SectionHeader>
         
         <div class="mb-4">
-          <p class="text-sm leading-relaxed text-gray-700" v-html="$t('grounding.science.description')"></p>
+          <p class="text-sm leading-relaxed text-gray-700 dark:text-gray-400" v-html="$t('grounding.science.description')"></p>
         </div>
 
         <div class="grid gap-4 md:grid-cols-3">
-          <div class="border border-purple-200 bg-purple-50 p-4">
+          <div class="border border-purple-200 bg-purple-50 p-4 dark:bg-purple-900/10 dark:border-purple-500/20">
             <div class="mb-2 flex items-center">
               <Icon name="ph:gear" class="mr-2 text-purple-600" />
-              <span class="text-sm font-medium text-gray-800">{{ $t("grounding.science.research.regulation.title") }}</span>
+              <span class="text-sm font-medium text-gray-800 dark:text-gray-200">{{ $t("grounding.science.research.regulation.title") }}</span>
             </div>
-            <p class="text-xs text-gray-600" v-html="$t('grounding.science.research.regulation.description')"></p>
+            <p class="text-xs text-gray-600 dark:text-gray-400" v-html="$t('grounding.science.research.regulation.description')"></p>
           </div>
           
-          <div class="border border-purple-200 bg-purple-50 p-4">
+          <div class="border border-purple-200 bg-purple-50 p-4 dark:bg-purple-900/10 dark:border-purple-500/20">
             <div class="mb-2 flex items-center">
               <Icon name="ph:heart" class="mr-2 text-purple-600" />
-              <span class="text-sm font-medium text-gray-800">{{ $t("grounding.science.research.anxiety.title") }}</span>
+              <span class="text-sm font-medium text-gray-800 dark:text-gray-200">{{ $t("grounding.science.research.anxiety.title") }}</span>
             </div>
-            <p class="text-xs text-gray-600" v-html="$t('grounding.science.research.anxiety.description')"></p>
+            <p class="text-xs text-gray-600 dark:text-gray-400" v-html="$t('grounding.science.research.anxiety.description')"></p>
           </div>
           
-          <div class="border border-purple-200 bg-purple-50 p-4">
+          <div class="border border-purple-200 bg-purple-50 p-4 dark:bg-purple-900/10 dark:border-purple-500/20">
             <div class="mb-2 flex items-center">
               <Icon name="ph:shield-check" class="mr-2 text-purple-600" />
-              <span class="text-sm font-medium text-gray-800">{{ $t("grounding.science.research.stability.title") }}</span>
+              <span class="text-sm font-medium text-gray-800 dark:text-gray-200">{{ $t("grounding.science.research.stability.title") }}</span>
             </div>
-            <p class="text-xs text-gray-600" v-html="$t('grounding.science.research.stability.description')"></p>
+            <p class="text-xs text-gray-600 dark:text-gray-400" v-html="$t('grounding.science.research.stability.description')"></p>
           </div>
         </div>
       </div>
@@ -77,11 +77,11 @@
     <section>
       <div class="grid gap-8 md:grid-cols-2">
         <!-- When to Use -->
-        <div class="border border-gray-200 bg-white/60 p-6">
+        <div class="border border-gray-200 bg-white/60 p-6 dark:bg-slate-800/20 dark:border-slate-700">
           <SectionHeader icon="ph:calendar-check" color="blue">
             {{ $t("grounding.whenToPractice.title") }}
           </SectionHeader>
-          <ul class="space-y-3 text-sm text-gray-700">
+          <ul class="space-y-3 text-sm text-gray-700 dark:text-gray-400">
             <li class="flex items-start">
               <Icon name="ph:lightning-fill" class="mr-2 mt-0.5 flex-shrink-0 text-red-500" />
               <span>{{ $t("grounding.whenToPractice.items.0") }}</span>
@@ -105,11 +105,11 @@
         </div>
 
         <!-- What You'll Experience -->
-        <div class="border border-gray-200 bg-white/60 p-6">
+        <div class="border border-gray-200 bg-white/60 p-6 dark:bg-slate-800/20 dark:border-slate-700">
           <SectionHeader icon="ph:trend-up" color="green">
             {{ $t("grounding.whatYoullNotice.title") }}
           </SectionHeader>
-          <ul class="space-y-3 text-sm text-gray-700">
+          <ul class="space-y-3 text-sm text-gray-700 dark:text-gray-400">
             <li class="flex items-start">
               <Icon name="ph:timer-fill" class="mr-2 mt-0.5 flex-shrink-0 text-blue-400" />
               <span>{{ $t("grounding.whatYoullNotice.items.0") }}</span>
@@ -133,27 +133,27 @@
 
     <!-- Tips Section -->
     <section>
-      <div class="border border-indigo-200 bg-indigo-50 p-6">
+      <div class="border border-indigo-200 bg-indigo-50 p-6 dark:bg-indigo-900/10 dark:border-indigo-500/20">
         <div class="mb-4 text-center">
           <Icon name="ph:lightbulb" class="mx-auto mb-2 text-2xl text-indigo-600" />
-          <h2 class="font-semibold text-gray-800">{{ $t("grounding.bestResults.title") }}</h2>
+          <h2 class="font-semibold text-gray-800 dark:text-gray-200">{{ $t("grounding.bestResults.title") }}</h2>
         </div>
         <div class="grid gap-4 text-sm md:grid-cols-3">
           <div class="text-center">
-            <div class="mb-1 font-medium text-indigo-600">{{ $t("grounding.bestResults.timing.title") }}</div>
-            <p class="text-gray-600">
+            <div class="mb-1 font-medium text-indigo-600 dark:text-indigo-400">{{ $t("grounding.bestResults.timing.title") }}</div>
+            <p class="text-gray-600 dark:text-gray-400">
               {{ $t("grounding.bestResults.timing.description") }}
             </p>
           </div>
           <div class="text-center">
-            <div class="mb-1 font-medium text-indigo-600">{{ $t("grounding.bestResults.detail.title") }}</div>
-            <p class="text-gray-600">
+            <div class="mb-1 font-medium text-indigo-600 dark:text-indigo-400">{{ $t("grounding.bestResults.detail.title") }}</div>
+            <p class="text-gray-600 dark:text-gray-400">
               {{ $t("grounding.bestResults.detail.description") }}
             </p>
           </div>
           <div class="text-center">
-            <div class="mb-1 font-medium text-indigo-600">{{ $t("grounding.bestResults.practice.title") }}</div>
-            <p class="text-gray-600">
+            <div class="mb-1 font-medium text-indigo-600 dark:text-indigo-400">{{ $t("grounding.bestResults.practice.title") }}</div>
+            <p class="text-gray-600 dark:text-gray-400">
               {{ $t("grounding.bestResults.practice.description") }}
             </p>
           </div>

--- a/pages/guided-breathing.vue
+++ b/pages/guided-breathing.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-gradient-to-br from-blue-50 via-indigo-50 to-purple-50 py-8">
+  <div class="min-h-screen bg-gradient-to-br from-blue-50 via-indigo-50 to-purple-50 py-8 dark:from-slate-800 dark:via-slate-900 dark:to-black">
     <Breadcrumb duration="3-5 min" />
 
     <!-- Exercise Component -->
@@ -8,68 +8,68 @@
     <section>
       <!-- Technique Overview -->
       <div class="mb-6 grid gap-6 md:grid-cols-2">
-        <div class="border border-blue-200 bg-blue-50 p-6">
+        <div class="border border-blue-200 bg-blue-50 p-6 dark:bg-blue-900/10 dark:border-blue-500/20">
           <div>
             <div class="flex items-center justify-start gap-2 mb-2">
               <Icon name="ph:squares-four" class="flex-shrink-0 text-2xl text-blue-600" />
-              <h2 class="font-semibold text-gray-800">{{ $t("guidedBreathing.techniquesOverview.boxBreathing.title") }}</h2>
+              <h2 class="font-semibold text-gray-800 dark:text-gray-200">{{ $t("guidedBreathing.techniquesOverview.boxBreathing.title") }}</h2>
             </div>
             <div class="px-1">
-              <p class="mb-3 text-sm leading-relaxed text-gray-700">
+              <p class="mb-3 text-sm leading-relaxed text-gray-700 dark:text-gray-400">
                 {{ $t("guidedBreathing.techniquesOverview.boxBreathing.description") }}
               </p>
-              <div class="text-xs font-medium text-blue-600">
+              <div class="text-xs font-medium text-blue-600 dark:text-blue-400">
                 {{ $t("guidedBreathing.techniquesOverview.boxBreathing.bestFor") }}
               </div>
             </div>
           </div>
         </div>
 
-        <div class="border border-purple-200 bg-purple-50 p-6">
+        <div class="border border-purple-200 bg-purple-50 p-6 dark:bg-purple-900/10 dark:border-purple-500/20">
           <div>
             <div class="flex items-center justify-start gap-2 mb-2">
               <Icon name="ph:moon-stars" class="flex-shrink-0 text-2xl text-purple-600" />
-              <h2 class="font-semibold text-gray-800">{{ $t("guidedBreathing.techniquesOverview.calming.title") }}</h2>
+              <h2 class="font-semibold text-gray-800 dark:text-gray-200">{{ $t("guidedBreathing.techniquesOverview.calming.title") }}</h2>
             </div>
             <div class="px-1">
-              <p class="mb-3 text-sm leading-relaxed text-gray-700">
+              <p class="mb-3 text-sm leading-relaxed text-gray-700 dark:text-gray-400">
                 {{ $t("guidedBreathing.techniquesOverview.calming.description") }}
               </p>
-              <div class="text-xs font-medium text-purple-600">
+              <div class="text-xs font-medium text-purple-600 dark:text-purple-400">
                 {{ $t("guidedBreathing.techniquesOverview.calming.bestFor") }}
               </div>
             </div>
           </div>
         </div>
 
-        <div class="border border-green-200 bg-green-50 p-6">
+        <div class="border border-green-200 bg-green-50 p-6 dark:bg-green-900/10 dark:border-green-500/20">
           <div>
             <div class="flex items-center justify-start gap-2 mb-2">
               <Icon name="ph:lightning" class="flex-shrink-0 text-2xl text-green-600" />
-              <h2 class="font-semibold text-gray-800">{{ $t("guidedBreathing.techniquesOverview.energizing.title") }}</h2>
+              <h2 class="font-semibold text-gray-800 dark:text-gray-200">{{ $t("guidedBreathing.techniquesOverview.energizing.title") }}</h2>
             </div>
             <div class="px-1">
-              <p class="mb-3 text-sm leading-relaxed text-gray-700">
+              <p class="mb-3 text-sm leading-relaxed text-gray-700 dark:text-gray-400">
                 {{ $t("guidedBreathing.techniquesOverview.energizing.description") }}
               </p>
-              <div class="text-xs font-medium text-green-600">
+              <div class="text-xs font-medium text-green-600 dark:text-green-400">
                 {{ $t("guidedBreathing.techniquesOverview.energizing.bestFor") }}
               </div>
             </div>
           </div>
         </div>
 
-        <div class="border border-orange-200 bg-orange-50 p-6">
+        <div class="border border-orange-200 bg-orange-50 p-6 dark:bg-orange-900/10 dark:border-orange-500/20">
           <div>
             <div class="flex items-center justify-start gap-2 mb-2">
               <Icon name="ph:clock" class="flex-shrink-0 text-2xl text-orange-600" />
-              <h2 class="font-semibold text-gray-800">{{ $t("guidedBreathing.techniquesOverview.quickReset.title") }}</h2>
+              <h2 class="font-semibold text-gray-800 dark:text-gray-200">{{ $t("guidedBreathing.techniquesOverview.quickReset.title") }}</h2>
             </div>
             <div class="px-1">
-              <p class="mb-3 text-sm leading-relaxed text-gray-700">
+              <p class="mb-3 text-sm leading-relaxed text-gray-700 dark:text-gray-400">
                 {{ $t("guidedBreathing.techniquesOverview.quickReset.description") }}
               </p>
-              <div class="text-xs font-medium text-orange-600">
+              <div class="text-xs font-medium text-orange-600 dark:text-orange-400">
                 {{ $t("guidedBreathing.techniquesOverview.quickReset.bestFor") }}
               </div>
             </div>
@@ -78,43 +78,43 @@
       </div>
 
       <!-- How It Works -->
-      <div class="border border-gray-200 bg-white/60 p-6">
+      <div class="border border-gray-200 bg-white/60 p-6 dark:bg-slate-800/20 dark:border-slate-700">
         <div>
           <SectionHeader icon="ph:brain" color="gray">
             {{ $t("guidedBreathing.howItWorks.title") }}
           </SectionHeader>
           <div class="px-1">
-            <p class="mb-3 text-sm leading-relaxed text-gray-700">
+            <p class="mb-3 text-sm leading-relaxed text-gray-700 dark:text-gray-400">
               {{ $t("guidedBreathing.howItWorks.description1") }}
             </p>
-            <p class="mb-3 text-sm leading-relaxed text-gray-700">
+            <p class="mb-3 text-sm leading-relaxed text-gray-700 dark:text-gray-400">
               {{ $t("guidedBreathing.howItWorks.description2") }}
             </p>
             <div class="mt-4 grid gap-4 md:grid-cols-3">
-              <div class="border border-gray-200 bg-white/60 p-3">
+              <div class="border border-gray-200 bg-white/60 p-3 dark:bg-slate-700/20 dark:border-slate-600">
                 <div class="mb-1 flex items-center">
                   <Icon name="ph:target" class="mr-2 text-gray-600" />
-                  <span class="text-xs font-medium text-gray-800">{{ $t("guidedBreathing.howItWorks.focusedAttention.title") }}</span>
+                  <span class="text-xs font-medium text-gray-800 dark:text-gray-200">{{ $t("guidedBreathing.howItWorks.focusedAttention.title") }}</span>
                 </div>
-                <p class="text-xs text-gray-600">
+                <p class="text-xs text-gray-600 dark:text-gray-400">
                   {{ $t("guidedBreathing.howItWorks.focusedAttention.description") }}
                 </p>
               </div>
-              <div class="border border-gray-200 bg-white/60 p-3">
+              <div class="border border-gray-200 bg-white/60 p-3 dark:bg-slate-700/20 dark:border-slate-600">
                 <div class="mb-1 flex items-center">
                   <Icon name="ph:activity" class="mr-2 text-gray-600" />
-                  <span class="text-xs font-medium text-gray-800">{{ $t("guidedBreathing.howItWorks.nervousSystem.title") }}</span>
+                  <span class="text-xs font-medium text-gray-800 dark:text-gray-200">{{ $t("guidedBreathing.howItWorks.nervousSystem.title") }}</span>
                 </div>
-                <p class="text-xs text-gray-600">
+                <p class="text-xs text-gray-600 dark:text-gray-400">
                   {{ $t("guidedBreathing.howItWorks.nervousSystem.description") }}
                 </p>
               </div>
-              <div class="border border-gray-200 bg-white/60 p-3">
+              <div class="border border-gray-200 bg-white/60 p-3 dark:bg-slate-700/20 dark:border-slate-600">
                 <div class="mb-1 flex items-center">
                   <Icon name="ph:repeat" class="mr-2 text-gray-600" />
-                  <span class="text-xs font-medium text-gray-800">{{ $t("guidedBreathing.howItWorks.skillBuilding.title") }}</span>
+                  <span class="text-xs font-medium text-gray-800 dark:text-gray-200">{{ $t("guidedBreathing.howItWorks.skillBuilding.title") }}</span>
                 </div>
-                <p class="text-xs text-gray-600">
+                <p class="text-xs text-gray-600 dark:text-gray-400">
                   {{ $t("guidedBreathing.howItWorks.skillBuilding.description") }}
                 </p>
               </div>
@@ -126,38 +126,38 @@
 
     <!-- Scientific Background -->
     <section>
-      <div class="border border-gray-200 bg-white/60 p-6">
+      <div class="border border-gray-200 bg-white/60 p-6 dark:bg-slate-800/20 dark:border-slate-700">
         <SectionHeader icon="ph:flask" color="purple">
           {{ $t("guidedBreathing.science.title") }}
         </SectionHeader>
         
         <div class="mb-4">
-          <p class="text-sm leading-relaxed text-gray-700" v-html="$t('guidedBreathing.science.description')"></p>
+          <p class="text-sm leading-relaxed text-gray-700 dark:text-gray-400" v-html="$t('guidedBreathing.science.description')"></p>
         </div>
 
         <div class="grid gap-4 md:grid-cols-3">
-          <div class="border border-purple-200 bg-purple-50 p-4">
+          <div class="border border-purple-200 bg-purple-50 p-4 dark:bg-purple-900/10 dark:border-purple-500/20">
             <div class="mb-2 flex items-center">
               <Icon name="ph:trend-up" class="mr-2 text-purple-600" />
-              <span class="text-sm font-medium text-gray-800">{{ $t("guidedBreathing.science.research.effectiveness.title") }}</span>
+              <span class="text-sm font-medium text-gray-800 dark:text-gray-200">{{ $t("guidedBreathing.science.research.effectiveness.title") }}</span>
             </div>
-            <p class="text-xs text-gray-600" v-html="$t('guidedBreathing.science.research.effectiveness.description')"></p>
+            <p class="text-xs text-gray-600 dark:text-gray-400" v-html="$t('guidedBreathing.science.research.effectiveness.description')"></p>
           </div>
           
-          <div class="border border-purple-200 bg-purple-50 p-4">
+          <div class="border border-purple-200 bg-purple-50 p-4 dark:bg-purple-900/10 dark:border-purple-500/20">
             <div class="mb-2 flex items-center">
               <Icon name="ph:hospital" class="mr-2 text-purple-600" />
-              <span class="text-sm font-medium text-gray-800">{{ $t("guidedBreathing.science.research.clinical.title") }}</span>
+              <span class="text-sm font-medium text-gray-800 dark:text-gray-200">{{ $t("guidedBreathing.science.research.clinical.title") }}</span>
             </div>
-            <p class="text-xs text-gray-600" v-html="$t('guidedBreathing.science.research.clinical.description')"></p>
+            <p class="text-xs text-gray-600 dark:text-gray-400" v-html="$t('guidedBreathing.science.research.clinical.description')"></p>
           </div>
           
-          <div class="border border-purple-200 bg-purple-50 p-4">
+          <div class="border border-purple-200 bg-purple-50 p-4 dark:bg-purple-900/10 dark:border-purple-500/20">
             <div class="mb-2 flex items-center">
               <Icon name="ph:calendar-plus" class="mr-2 text-purple-600" />
-              <span class="text-sm font-medium text-gray-800">{{ $t("guidedBreathing.science.research.longterm.title") }}</span>
+              <span class="text-sm font-medium text-gray-800 dark:text-gray-200">{{ $t("guidedBreathing.science.research.longterm.title") }}</span>
             </div>
-            <p class="text-xs text-gray-600" v-html="$t('guidedBreathing.science.research.longterm.description')"></p>
+            <p class="text-xs text-gray-600 dark:text-gray-400" v-html="$t('guidedBreathing.science.research.longterm.description')"></p>
           </div>
         </div>
       </div>
@@ -166,11 +166,11 @@
     <section>
       <div class="grid gap-8 md:grid-cols-2">
         <!-- When to Use -->
-        <div class="border border-gray-200 bg-white/60 p-6">
+        <div class="border border-gray-200 bg-white/60 p-6 dark:bg-slate-800/20 dark:border-slate-700">
           <SectionHeader icon="ph:calendar-check" color="blue">
             {{ $t("guidedBreathing.whenToPractice.title") }}
           </SectionHeader>
-          <ul class="space-y-3 text-sm text-gray-700">
+          <ul class="space-y-3 text-sm text-gray-700 dark:text-gray-400">
             <li class="flex items-start">
               <Icon name="ph:sun" class="mr-2 mt-0.5 flex-shrink-0 text-yellow-500" />
               <span>{{ $t("guidedBreathing.whenToPractice.items.0") }}</span>
@@ -191,11 +191,11 @@
         </div>
 
         <!-- What You'll Experience -->
-        <div class="border border-gray-200 bg-white/60 p-6">
+        <div class="border border-gray-200 bg-white/60 p-6 dark:bg-slate-800/20 dark:border-slate-700">
           <SectionHeader icon="ph:trend-up" color="green">
             {{ $t("guidedBreathing.whatYoullNotice.title") }}
           </SectionHeader>
-          <ul class="space-y-3 text-sm text-gray-700">
+          <ul class="space-y-3 text-sm text-gray-700 dark:text-gray-400">
             <li class="flex items-start">
               <Icon name="ph:timer-fill" class="mr-2 mt-0.5 flex-shrink-0 text-blue-400" />
               <span>{{ $t("guidedBreathing.whatYoullNotice.items.0") }}</span>
@@ -219,27 +219,27 @@
 
     <!-- Tips Section -->
     <section>
-      <div class="border border-indigo-200 bg-indigo-50 p-6">
+      <div class="border border-indigo-200 bg-indigo-50 p-6 dark:bg-indigo-900/10 dark:border-indigo-500/20">
         <div class="mb-4 text-center">
           <Icon name="ph:lightbulb" class="mx-auto mb-2 text-2xl text-indigo-600" />
-          <h2 class="font-semibold text-gray-800">{{ $t("guidedBreathing.tips.title") }}</h2>
+          <h2 class="font-semibold text-gray-800 dark:text-gray-200">{{ $t("guidedBreathing.tips.title") }}</h2>
         </div>
         <div class="grid gap-4 text-sm md:grid-cols-3">
           <div class="text-center">
-            <div class="mb-1 font-medium text-indigo-600">{{ $t("guidedBreathing.tips.posture.title") }}</div>
-            <p class="text-gray-600">
+            <div class="mb-1 font-medium text-indigo-600 dark:text-indigo-400">{{ $t("guidedBreathing.tips.posture.title") }}</div>
+            <p class="text-gray-600 dark:text-gray-400">
               {{ $t("guidedBreathing.tips.posture.description") }}
             </p>
           </div>
           <div class="text-center">
-            <div class="mb-1 font-medium text-indigo-600">{{ $t("guidedBreathing.tips.environment.title") }}</div>
-            <p class="text-gray-600">
+            <div class="mb-1 font-medium text-indigo-600 dark:text-indigo-400">{{ $t("guidedBreathing.tips.environment.title") }}</div>
+            <p class="text-gray-600 dark:text-gray-400">
               {{ $t("guidedBreathing.tips.environment.description") }}
             </p>
           </div>
           <div class="text-center">
-            <div class="mb-1 font-medium text-indigo-600">{{ $t("guidedBreathing.tips.consistency.title") }}</div>
-            <p class="text-gray-600">
+            <div class="mb-1 font-medium text-indigo-600 dark:text-indigo-400">{{ $t("guidedBreathing.tips.consistency.title") }}</div>
+            <p class="text-gray-600 dark:text-gray-400">
               {{ $t("guidedBreathing.tips.consistency.description") }}
             </p>
           </div>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -3,10 +3,10 @@
     <!-- Hero Section -->
     <section class="py-8 pt-20">
       <div class="mx-auto max-w-6xl text-center">
-        <h1 class="mb-3 text-4xl font-bold text-gray-800 md:text-5xl">
+        <h1 class="mb-3 text-4xl font-bold text-gray-800 md:text-5xl dark:text-gray-200">
           {{ $t("hero.title") }}
         </h1>
-        <p class="mx-auto mb-6 max-w-2xl text-base text-gray-600">
+        <p class="mx-auto mb-6 max-w-2xl text-base text-gray-600 dark:text-gray-400">
           {{ $t("hero.description") }}
         </p>
       </div>
@@ -25,30 +25,30 @@
         <h2 class="ptitle">{{ $t("about.title") }}</h2>
 
         <div class="mb-6 grid grid-cols-1 gap-6 md:grid-cols-2">
-          <div class="border border-amber-200 bg-amber-50 p-4">
+          <div class="border border-amber-200 bg-amber-50 p-4 dark:bg-amber-900/10 dark:border-amber-500/20">
             <div>
               <div class="flex items-center justify-start gap-2 mb-2">
                 <Icon name="ph:warning-fill" class="flex-shrink-0 text-lg text-amber-600" />
-                <h3 class="font-semibold text-gray-800">
+                <h3 class="font-semibold text-gray-800 dark:text-gray-200">
                   {{ $t("about.whatHappens.title") }}
                 </h3>
               </div>
-              <p class="text-sm leading-relaxed text-gray-700 px-1">
+              <p class="text-sm leading-relaxed text-gray-700 px-1 dark:text-gray-400">
                 {{ $t("about.whatHappens.description") }}
               </p>
             </div>
           </div>
 
-          <div class="border border-green-200 bg-green-50 p-4">
+          <div class="border border-green-200 bg-green-50 p-4 dark:bg-green-900/10 dark:border-green-500/20">
             <div>
               <div class="flex items-center justify-start gap-2 mb-2">
                 <Icon
                   name="ph:check-circle-fill"
                   class="flex-shrink-0 text-lg text-green-600"
                 />
-                <h3 class="font-semibold text-gray-800">{{ $t("about.howHelp.title") }}</h3>
+                <h3 class="font-semibold text-gray-800 dark:text-gray-200">{{ $t("about.howHelp.title") }}</h3>
               </div>
-              <p class="text-sm leading-relaxed text-gray-700 px-1">
+              <p class="text-sm leading-relaxed text-gray-700 px-1 dark:text-gray-400">
                 {{ $t("about.howHelp.description") }}
               </p>
             </div>
@@ -56,16 +56,16 @@
 
         </div>
 
-        <div class="border border-blue-200 bg-blue-50 p-4">
+        <div class="border border-blue-200 bg-blue-50 p-4 dark:bg-blue-900/10 dark:border-blue-500/20">
           <div>
             <div class="flex items-center justify-start gap-2 mb-2">
               <Icon
                 name="ph:lightbulb-fill"
                 class="flex-shrink-0 text-lg text-blue-600"
               />
-              <h3 class="font-semibold text-gray-800">{{ $t("about.tips.title") }}</h3>
+              <h3 class="font-semibold text-gray-800 dark:text-gray-200">{{ $t("about.tips.title") }}</h3>
             </div>
-            <ul class="list-inside list-disc space-y-1 text-sm text-gray-700 px-1">
+            <ul class="list-inside list-disc space-y-1 text-sm text-gray-700 px-1 dark:text-gray-400">
               <li v-for="tip in $tm('about.tips.items')" :key="tip">{{ $rt(tip) }}</li>
             </ul>
           </div>
@@ -77,41 +77,41 @@
     <!-- Resources Section -->
     <section id="resources" class="!mb-0 py-12 pb-24">
       <div class="mx-auto max-w-6xl">
-        <h2 class="ptitle">{{ $t("resources.title") }}</h2>
+        <h2 class="ptitle dark:text-gray-200">{{ $t("resources.title") }}</h2>
 
         <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-          <div class="border border-gray-200 bg-white bg-opacity-80 p-4">
+          <div class="border border-gray-200 bg-white bg-opacity-80 p-4 dark:bg-slate-800/20 dark:border-slate-700">
             <div class="flex items-center justify-start gap-2 mb-2">
               <Icon name="ph:user-circle-fill" class="flex-shrink-0 text-lg text-blue-600" />
-              <h3 class="font-semibold text-gray-800">
+              <h3 class="font-semibold text-gray-800 dark:text-gray-200">
                 {{ $t("resources.professional.title") }}
               </h3>
             </div>
-            <p class="mb-3 text-sm text-gray-700">
+            <p class="mb-3 text-sm text-gray-700 dark:text-gray-400">
               {{ $t("resources.professional.description") }}
             </p>
-            <ul class="list-inside list-disc space-y-1 text-sm text-gray-700">
+            <ul class="list-inside list-disc space-y-1 text-sm text-gray-700 dark:text-gray-400">
               <li v-for="sign in $tm('resources.professional.signs')" :key="sign">
                 {{ $rt(sign) }}
               </li>
             </ul>
           </div>
 
-          <div class="border border-gray-200 bg-white bg-opacity-80 p-4">
+          <div class="border border-gray-200 bg-white bg-opacity-80 p-4 dark:bg-slate-800/20 dark:border-slate-700">
             <div class="flex items-center justify-start gap-2 mb-2">
               <Icon name="ph:buildings-fill" class="flex-shrink-0 text-lg text-green-600" />
-              <h3 class="font-semibold text-gray-800">{{ $t("resources.organizations.title") }}</h3>
+              <h3 class="font-semibold text-gray-800 dark:text-gray-200">{{ $t("resources.organizations.title") }}</h3>
             </div>
-            <p class="mb-3 text-sm text-gray-700">
+            <p class="mb-3 text-sm text-gray-700 dark:text-gray-400">
               {{ $t("resources.organizations.description") }}
             </p>
-            <ul class="space-y-2 text-sm text-gray-700">
+            <ul class="space-y-2 text-sm text-gray-700 dark:text-gray-400">
               <li v-for="org in $tm('resources.organizations.list')" :key="org.name">
                 <div>
-                  <a :href="$rt(org.url)" target="_blank" rel="noopener noreferrer nofollow" class="font-medium text-blue-600 hover:text-blue-700 transition-colors duration-100">
+                  <a :href="$rt(org.url)" target="_blank" rel="noopener noreferrer nofollow" class="font-medium text-blue-600 hover:text-blue-700 transition-colors duration-100 dark:text-blue-400 dark:hover:text-blue-300">
                     {{ $rt(org.name) }}
                   </a>
-                  <p class="text-gray-600 mt-1">{{ $rt(org.description) }}</p>
+                  <p class="text-gray-600 mt-1 dark:text-gray-500">{{ $rt(org.description) }}</p>
                 </div>
               </li>
             </ul>

--- a/pages/peaceful-visualization.vue
+++ b/pages/peaceful-visualization.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-gradient-to-br from-green-50 via-blue-50 to-purple-50 py-8">
+  <div class="min-h-screen bg-gradient-to-br from-green-50 via-blue-50 to-purple-50 py-8 dark:from-slate-800 dark:via-slate-900 dark:to-black">
     <Breadcrumb duration="10-12 min" />
 
     <!-- Exercise Component -->
@@ -7,16 +7,16 @@
 
     <!-- Educational Content -->
     <section>
-      <div class="border border-gray-200 bg-white/60 p-6">
+      <div class="border border-gray-200 bg-white/60 p-6 dark:bg-slate-800/20 dark:border-slate-700">
         <div>
           <SectionHeader icon="ph:brain" color="gray">
             {{ $t("peacefulVisualization.howItWorks.title") }}
           </SectionHeader>
           <div class="px-1">
-            <p class="mb-3 text-sm leading-relaxed text-gray-700">
+            <p class="mb-3 text-sm leading-relaxed text-gray-700 dark:text-gray-400">
               {{ $t("peacefulVisualization.howItWorks.description") }}
             </p>
-            <p class="text-sm leading-relaxed text-gray-700">
+            <p class="text-sm leading-relaxed text-gray-700 dark:text-gray-400">
               {{ $t("peacefulVisualization.howItWorks.multisensory") }}
             </p>
           </div>
@@ -26,38 +26,38 @@
 
     <!-- Scientific Background -->
     <section>
-      <div class="border border-gray-200 bg-white/60 p-6">
+      <div class="border border-gray-200 bg-white/60 p-6 dark:bg-slate-800/20 dark:border-slate-700">
         <SectionHeader icon="ph:flask" color="purple">
           {{ $t("peacefulVisualization.science.title") }}
         </SectionHeader>
         
         <div class="mb-4">
-          <p class="text-sm leading-relaxed text-gray-700" v-html="$t('peacefulVisualization.science.description')"></p>
+          <p class="text-sm leading-relaxed text-gray-700 dark:text-gray-400" v-html="$t('peacefulVisualization.science.description')"></p>
         </div>
 
         <div class="grid gap-4 md:grid-cols-3">
-          <div class="border border-purple-200 bg-purple-50 p-4">
+          <div class="border border-purple-200 bg-purple-50 p-4 dark:bg-purple-900/10 dark:border-purple-500/20">
             <div class="mb-2 flex items-center">
               <Icon name="ph:chart-line" class="mr-2 text-purple-600" />
-              <span class="text-sm font-medium text-gray-800">{{ $t("peacefulVisualization.science.research.effectiveness.title") }}</span>
+              <span class="text-sm font-medium text-gray-800 dark:text-gray-200">{{ $t("peacefulVisualization.science.research.effectiveness.title") }}</span>
             </div>
-            <p class="text-xs text-gray-600" v-html="$t('peacefulVisualization.science.research.effectiveness.description')"></p>
+            <p class="text-xs text-gray-600 dark:text-gray-400" v-html="$t('peacefulVisualization.science.research.effectiveness.description')"></p>
           </div>
           
-          <div class="border border-purple-200 bg-purple-50 p-4">
+          <div class="border border-purple-200 bg-purple-50 p-4 dark:bg-purple-900/10 dark:border-purple-500/20">
             <div class="mb-2 flex items-center">
               <Icon name="ph:hospital" class="mr-2 text-purple-600" />
-              <span class="text-sm font-medium text-gray-800">{{ $t("peacefulVisualization.science.research.medical.title") }}</span>
+              <span class="text-sm font-medium text-gray-800 dark:text-gray-200">{{ $t("peacefulVisualization.science.research.medical.title") }}</span>
             </div>
-            <p class="text-xs text-gray-600" v-html="$t('peacefulVisualization.science.research.medical.description')"></p>
+            <p class="text-xs text-gray-600 dark:text-gray-400" v-html="$t('peacefulVisualization.science.research.medical.description')"></p>
           </div>
           
-          <div class="border border-purple-200 bg-purple-50 p-4">
+          <div class="border border-purple-200 bg-purple-50 p-4 dark:bg-purple-900/10 dark:border-purple-500/20">
             <div class="mb-2 flex items-center">
               <Icon name="ph:heart" class="mr-2 text-purple-600" />
-              <span class="text-sm font-medium text-gray-800">{{ $t("peacefulVisualization.science.research.physiological.title") }}</span>
+              <span class="text-sm font-medium text-gray-800 dark:text-gray-200">{{ $t("peacefulVisualization.science.research.physiological.title") }}</span>
             </div>
-            <p class="text-xs text-gray-600" v-html="$t('peacefulVisualization.science.research.physiological.description')"></p>
+            <p class="text-xs text-gray-600 dark:text-gray-400" v-html="$t('peacefulVisualization.science.research.physiological.description')"></p>
           </div>
         </div>
       </div>
@@ -66,11 +66,11 @@
     <section>
       <div class="grid gap-8 md:grid-cols-2">
         <!-- When to Use -->
-        <div class="border border-gray-200 bg-white/60 p-6">
+        <div class="border border-gray-200 bg-white/60 p-6 dark:bg-slate-800/20 dark:border-slate-700">
           <SectionHeader icon="ph:calendar-check" color="blue">
             {{ $t("peacefulVisualization.whenToPractice.title") }}
           </SectionHeader>
-          <ul class="space-y-3 text-sm text-gray-700">
+          <ul class="space-y-3 text-sm text-gray-700 dark:text-gray-400">
             <li class="flex items-start" v-for="item in $tm('peacefulVisualization.whenToPractice.items')" :key="item">
               <Icon name="ph:sun" class="mr-2 mt-0.5 flex-shrink-0 text-yellow-500" v-if="$tm('peacefulVisualization.whenToPractice.items').indexOf(item) === 0" />
               <Icon name="ph:briefcase" class="mr-2 mt-0.5 flex-shrink-0 text-gray-500" v-else-if="$tm('peacefulVisualization.whenToPractice.items').indexOf(item) === 1" />
@@ -82,11 +82,11 @@
         </div>
 
         <!-- What You'll Experience -->
-        <div class="border border-gray-200 bg-white/60 p-6">
+        <div class="border border-gray-200 bg-white/60 p-6 dark:bg-slate-800/20 dark:border-slate-700">
           <SectionHeader icon="ph:trend-up" color="green">
             {{ $t("peacefulVisualization.whatYoullNotice.title") }}
           </SectionHeader>
-          <ul class="space-y-3 text-sm text-gray-700">
+          <ul class="space-y-3 text-sm text-gray-700 dark:text-gray-400">
             <li class="flex items-start" v-for="item in $tm('peacefulVisualization.whatYoullNotice.items')" :key="item">
               <Icon name="ph:brain" class="mr-2 mt-0.5 flex-shrink-0 text-purple-400" v-if="$tm('peacefulVisualization.whatYoullNotice.items').indexOf(item) === 0" />
               <Icon name="ph:heart" class="mr-2 mt-0.5 flex-shrink-0 text-red-400" v-else-if="$tm('peacefulVisualization.whatYoullNotice.items').indexOf(item) === 1" />
@@ -101,27 +101,27 @@
 
     <!-- Tips Section -->
     <section>
-      <div class="border border-indigo-200 bg-indigo-50 p-6">
+      <div class="border border-indigo-200 bg-indigo-50 p-6 dark:bg-indigo-900/10 dark:border-indigo-500/20">
         <div class="mb-4 text-center">
           <Icon name="ph:lightbulb" class="mx-auto mb-2 text-2xl text-indigo-600" />
-          <h2 class="font-semibold text-gray-800">{{ $t("peacefulVisualization.tips.title") }}</h2>
+          <h2 class="font-semibold text-gray-800 dark:text-gray-200">{{ $t("peacefulVisualization.tips.title") }}</h2>
         </div>
         <div class="grid gap-4 text-sm md:grid-cols-3">
           <div class="text-center">
-            <div class="mb-1 font-medium text-indigo-600">{{ $t("peacefulVisualization.tips.preparation.title") }}</div>
-            <p class="text-gray-600">
+            <div class="mb-1 font-medium text-indigo-600 dark:text-indigo-400">{{ $t("peacefulVisualization.tips.preparation.title") }}</div>
+            <p class="text-gray-600 dark:text-gray-400">
               {{ $t("peacefulVisualization.tips.preparation.description") }}
             </p>
           </div>
           <div class="text-center">
-            <div class="mb-1 font-medium text-indigo-600">{{ $t("peacefulVisualization.tips.engagement.title") }}</div>
-            <p class="text-gray-600">
+            <div class="mb-1 font-medium text-indigo-600 dark:text-indigo-400">{{ $t("peacefulVisualization.tips.engagement.title") }}</div>
+            <p class="text-gray-600 dark:text-gray-400">
               {{ $t("peacefulVisualization.tips.engagement.description") }}
             </p>
           </div>
           <div class="text-center">
-            <div class="mb-1 font-medium text-indigo-600">{{ $t("peacefulVisualization.tips.patience.title") }}</div>
-            <p class="text-gray-600">
+            <div class="mb-1 font-medium text-indigo-600 dark:text-indigo-400">{{ $t("peacefulVisualization.tips.patience.title") }}</div>
+            <p class="text-gray-600 dark:text-gray-400">
               {{ $t("peacefulVisualization.tips.patience.description") }}
             </p>
           </div>

--- a/pages/progressive-muscle-relaxation.vue
+++ b/pages/progressive-muscle-relaxation.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-gradient-to-br from-blue-50 via-indigo-50 to-purple-50 py-8">
+  <div class="min-h-screen bg-gradient-to-br from-blue-50 via-indigo-50 to-purple-50 py-8 dark:from-slate-800 dark:via-slate-900 dark:to-black">
     <Breadcrumb duration="12-15 min" />
 
     <!-- Exercise Component -->
@@ -8,37 +8,37 @@
     <!-- Why It Works Section -->
     <section>
       <!-- How PMR Helps -->
-      <div class="border border-gray-200 bg-white/60 p-6">
+      <div class="border border-gray-200 bg-white/60 p-6 dark:bg-slate-800/20 dark:border-slate-700">
         <div>
           <SectionHeader icon="ph:heart-fill" color="indigo">
             {{ $t("progressiveMuscleRelaxation.howItWorks.title") }}
           </SectionHeader>
           <div class="px-1">
-            <p class="mb-3 text-sm leading-relaxed text-gray-700">
+            <p class="mb-3 text-sm leading-relaxed text-gray-700 dark:text-gray-400">
               {{ $t("progressiveMuscleRelaxation.howItWorks.description") }}
             </p>
-            <p class="mb-3 text-sm leading-relaxed text-gray-700">
+            <p class="mb-3 text-sm leading-relaxed text-gray-700 dark:text-gray-400">
               {{ $t("progressiveMuscleRelaxation.howItWorks.physiology") }}
             </p>
-            <p class="mb-3 text-sm leading-relaxed text-gray-700">
+            <p class="mb-3 text-sm leading-relaxed text-gray-700 dark:text-gray-400">
               {{ $t("progressiveMuscleRelaxation.howItWorks.awareness") }}
             </p>
             <div class="mt-4 grid gap-4 md:grid-cols-2">
-              <div class="border border-gray-200 bg-white/60 p-4">
+              <div class="border border-gray-200 bg-white/60 p-4 dark:bg-slate-700/20 dark:border-slate-600">
                 <div class="mb-2 flex items-center">
                   <Icon name="ph:lightning" class="mr-2 text-indigo-600" />
-                  <span class="font-medium text-gray-800">{{ $t("progressiveMuscleRelaxation.howItWorks.tension.title") }}</span>
+                  <span class="font-medium text-gray-800 dark:text-gray-200">{{ $t("progressiveMuscleRelaxation.howItWorks.tension.title") }}</span>
                 </div>
-                <p class="text-xs text-gray-600">
+                <p class="text-xs text-gray-600 dark:text-gray-400">
                   {{ $t("progressiveMuscleRelaxation.howItWorks.tension.description") }}
                 </p>
               </div>
-              <div class="border border-gray-200 bg-white/60 p-4">
+              <div class="border border-gray-200 bg-white/60 p-4 dark:bg-slate-700/20 dark:border-slate-600">
                 <div class="mb-2 flex items-center">
                   <Icon name="ph:hand-peace" class="mr-2 text-indigo-600" />
-                  <span class="font-medium text-gray-800">{{ $t("progressiveMuscleRelaxation.howItWorks.release.title") }}</span>
+                  <span class="font-medium text-gray-800 dark:text-gray-200">{{ $t("progressiveMuscleRelaxation.howItWorks.release.title") }}</span>
                 </div>
-                <p class="text-xs text-gray-600">
+                <p class="text-xs text-gray-600 dark:text-gray-400">
                   {{ $t("progressiveMuscleRelaxation.howItWorks.release.description") }}
                 </p>
               </div>
@@ -50,38 +50,38 @@
 
     <!-- Scientific Background -->
     <section>
-      <div class="border border-gray-200 bg-white/60 p-6">
+      <div class="border border-gray-200 bg-white/60 p-6 dark:bg-slate-800/20 dark:border-slate-700">
         <SectionHeader icon="ph:flask" color="purple">
           {{ $t("progressiveMuscleRelaxation.science.title") }}
         </SectionHeader>
         
         <div class="mb-4">
-          <p class="text-sm leading-relaxed text-gray-700" v-html="$t('progressiveMuscleRelaxation.science.description')"></p>
+          <p class="text-sm leading-relaxed text-gray-700 dark:text-gray-400" v-html="$t('progressiveMuscleRelaxation.science.description')"></p>
         </div>
 
         <div class="grid gap-4 md:grid-cols-3">
-          <div class="border border-purple-200 bg-purple-50 p-4">
+          <div class="border border-purple-200 bg-purple-50 p-4 dark:bg-purple-900/10 dark:border-purple-500/20">
             <div class="mb-2 flex items-center">
               <Icon name="ph:heart" class="mr-2 text-purple-600" />
-              <span class="text-sm font-medium text-gray-800">{{ $t("progressiveMuscleRelaxation.science.research.anxiety.title") }}</span>
+              <span class="text-sm font-medium text-gray-800 dark:text-gray-200">{{ $t("progressiveMuscleRelaxation.science.research.anxiety.title") }}</span>
             </div>
-            <p class="text-xs text-gray-600" v-html="$t('progressiveMuscleRelaxation.science.research.anxiety.description')"></p>
+            <p class="text-xs text-gray-600 dark:text-gray-400" v-html="$t('progressiveMuscleRelaxation.science.research.anxiety.description')"></p>
           </div>
           
-          <div class="border border-purple-200 bg-purple-50 p-4">
+          <div class="border border-purple-200 bg-purple-50 p-4 dark:bg-purple-900/10 dark:border-purple-500/20">
             <div class="mb-2 flex items-center">
               <Icon name="ph:hospital" class="mr-2 text-purple-600" />
-              <span class="text-sm font-medium text-gray-800">{{ $t("progressiveMuscleRelaxation.science.research.medical.title") }}</span>
+              <span class="text-sm font-medium text-gray-800 dark:text-gray-200">{{ $t("progressiveMuscleRelaxation.science.research.medical.title") }}</span>
             </div>
-            <p class="text-xs text-gray-600" v-html="$t('progressiveMuscleRelaxation.science.research.medical.description')"></p>
+            <p class="text-xs text-gray-600 dark:text-gray-400" v-html="$t('progressiveMuscleRelaxation.science.research.medical.description')"></p>
           </div>
           
-          <div class="border border-purple-200 bg-purple-50 p-4">
+          <div class="border border-purple-200 bg-purple-50 p-4 dark:bg-purple-900/10 dark:border-purple-500/20">
             <div class="mb-2 flex items-center">
               <Icon name="ph:calendar-plus" class="mr-2 text-purple-600" />
-              <span class="text-sm font-medium text-gray-800">{{ $t("progressiveMuscleRelaxation.science.research.longterm.title") }}</span>
+              <span class="text-sm font-medium text-gray-800 dark:text-gray-200">{{ $t("progressiveMuscleRelaxation.science.research.longterm.title") }}</span>
             </div>
-            <p class="text-xs text-gray-600" v-html="$t('progressiveMuscleRelaxation.science.research.longterm.description')"></p>
+            <p class="text-xs text-gray-600 dark:text-gray-400" v-html="$t('progressiveMuscleRelaxation.science.research.longterm.description')"></p>
           </div>
         </div>
       </div>
@@ -90,11 +90,11 @@
     <section>
       <div class="grid gap-8 md:grid-cols-2">
         <!-- When to Use -->
-        <div class="border border-gray-200 bg-white/60 p-6">
+        <div class="border border-gray-200 bg-white/60 p-6 dark:bg-slate-800/20 dark:border-slate-700">
           <SectionHeader icon="ph:calendar-check" color="blue">
             {{ $t("progressiveMuscleRelaxation.whenToPractice.title") }}
           </SectionHeader>
-          <ul class="space-y-3 text-sm text-gray-700">
+          <ul class="space-y-3 text-sm text-gray-700 dark:text-gray-400">
             <li class="flex items-start" v-for="(item, index) in $tm('progressiveMuscleRelaxation.whenToPractice.items')" :key="item">
               <Icon :name="['ph:moon', 'ph:lightning-slash', 'ph:brain', 'ph:shield-check'][index]" :class="[['text-blue-400', 'text-purple-400', 'text-green-400', 'text-orange-400'][index], 'mr-2 mt-0.5 flex-shrink-0']" />
               <span>{{ $rt(item) }}</span>
@@ -103,11 +103,11 @@
         </div>
 
         <!-- What You'll Experience -->
-        <div class="border border-gray-200 bg-white/60 p-6">
+        <div class="border border-gray-200 bg-white/60 p-6 dark:bg-slate-800/20 dark:border-slate-700">
           <SectionHeader icon="ph:trend-up" color="green">
             {{ $t("progressiveMuscleRelaxation.whatYoullNotice.title") }}
           </SectionHeader>
-          <ul class="space-y-3 text-sm text-gray-700">
+          <ul class="space-y-3 text-sm text-gray-700 dark:text-gray-400">
             <li class="flex items-start" v-for="(item, index) in $tm('progressiveMuscleRelaxation.whatYoullNotice.items')" :key="item">
               <Icon :name="['ph:timer-fill', 'ph:brain', 'ph:heart', 'ph:shield-check'][index]" :class="[['text-blue-400', 'text-purple-400', 'text-red-400', 'text-green-400'][index], 'mr-2 mt-0.5 flex-shrink-0']" />
               <span>{{ $rt(item) }}</span>
@@ -119,27 +119,27 @@
 
     <!-- Tips Section -->
     <section>
-      <div class="border border-indigo-200 bg-indigo-50 p-6">
+      <div class="border border-indigo-200 bg-indigo-50 p-6 dark:bg-indigo-900/10 dark:border-indigo-500/20">
         <div class="mb-4 text-center">
           <Icon name="ph:lightbulb" class="mx-auto mb-2 text-2xl text-indigo-600" />
-          <h2 class="font-semibold text-gray-800">{{ $t("progressiveMuscleRelaxation.bestResults.title") }}</h2>
+          <h2 class="font-semibold text-gray-800 dark:text-gray-200">{{ $t("progressiveMuscleRelaxation.bestResults.title") }}</h2>
         </div>
         <div class="grid gap-4 text-sm md:grid-cols-3">
           <div class="text-center">
-            <div class="mb-1 font-medium text-indigo-600">{{ $t("progressiveMuscleRelaxation.bestResults.environment.title") }}</div>
-            <p class="text-gray-600">
+            <div class="mb-1 font-medium text-indigo-600 dark:text-indigo-400">{{ $t("progressiveMuscleRelaxation.bestResults.environment.title") }}</div>
+            <p class="text-gray-600 dark:text-gray-400">
               {{ $t("progressiveMuscleRelaxation.bestResults.environment.description") }}
             </p>
           </div>
           <div class="text-center">
-            <div class="mb-1 font-medium text-indigo-600">{{ $t("progressiveMuscleRelaxation.bestResults.tension.title") }}</div>
-            <p class="text-gray-600">
+            <div class="mb-1 font-medium text-indigo-600 dark:text-indigo-400">{{ $t("progressiveMuscleRelaxation.bestResults.tension.title") }}</div>
+            <p class="text-gray-600 dark:text-gray-400">
               {{ $t("progressiveMuscleRelaxation.bestResults.tension.description") }}
             </p>
           </div>
           <div class="text-center">
-            <div class="mb-1 font-medium text-indigo-600">{{ $t("progressiveMuscleRelaxation.bestResults.consistency.title") }}</div>
-            <p class="text-gray-600">
+            <div class="mb-1 font-medium text-indigo-600 dark:text-indigo-400">{{ $t("progressiveMuscleRelaxation.bestResults.consistency.title") }}</div>
+            <p class="text-gray-600 dark:text-gray-400">
               {{ $t("progressiveMuscleRelaxation.bestResults.consistency.description") }}
             </p>
           </div>

--- a/pages/sound-therapy.vue
+++ b/pages/sound-therapy.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-gradient-to-br from-purple-50 via-indigo-50 to-blue-50 py-8">
+  <div class="min-h-screen bg-gradient-to-br from-purple-50 via-indigo-50 to-blue-50 py-8 dark:from-slate-800 dark:via-slate-900 dark:to-black">
     <Breadcrumb duration="5-20 min" />
 
     <!-- Exercise Component -->
@@ -10,16 +10,16 @@
           <div class="mb-6">
             <Icon name="ph:waveform-fill" class="mx-auto text-6xl text-purple-600" />
           </div>
-          <h1 class="ptitle">Sound Therapy & Frequency Healing</h1>
-          <p class="mx-auto mb-6 max-w-2xl leading-relaxed text-gray-600">
+          <h1 class="ptitle dark:text-gray-200">Sound Therapy & Frequency Healing</h1>
+          <p class="mx-auto mb-6 max-w-2xl leading-relaxed text-gray-600 dark:text-gray-400">
             {{ $t("soundTherapy.description") }}
           </p>
 
           <!-- Main Control Panel -->
-          <div class="mb-6 border border-gray-200 bg-white p-6 md:p-8">
+          <div class="mb-6 border border-gray-200 bg-white p-6 md:p-8 dark:bg-slate-800/20 dark:border-slate-700">
             <!-- Frequency Selection -->
             <div class="mb-8">
-              <h4 class="mb-6 text-xl font-medium text-gray-900">{{ $t("soundTherapy.interface.frequency") }}</h4>
+              <h4 class="mb-6 text-xl font-medium text-gray-900 dark:text-gray-200">{{ $t("soundTherapy.interface.frequency") }}</h4>
               <div class="grid grid-cols-2 gap-3 lg:grid-cols-4">
                 <button
                   v-for="freq in frequencies"
@@ -28,12 +28,12 @@
                   :class="[
                     'border p-4 text-left transition-all duration-200 hover:border-purple-300',
                     selectedFrequency?.value === freq.value
-                      ? 'border-purple-500 bg-purple-50'
-                      : 'border-gray-200 bg-white',
+                      ? 'border-purple-500 bg-purple-50 dark:bg-purple-900/20 dark:border-purple-500/50'
+                      : 'border-gray-200 bg-white dark:bg-slate-700/20 dark:border-slate-600',
                   ]"
                 >
-                  <div class="text-sm font-semibold text-gray-900">{{ $t(`soundTherapy.frequencies.${freq.index}.name`) }}</div>
-                  <div class="mt-1 text-xs leading-tight text-gray-500">{{ $t(`soundTherapy.frequencies.${freq.index}.description`) }}</div>
+                  <div class="text-sm font-semibold text-gray-900 dark:text-gray-200">{{ $t(`soundTherapy.frequencies.${freq.index}.name`) }}</div>
+                  <div class="mt-1 text-xs leading-tight text-gray-500 dark:text-gray-400">{{ $t(`soundTherapy.frequencies.${freq.index}.description`) }}</div>
                 </button>
               </div>
             </div>
@@ -42,7 +42,7 @@
             <div class="mb-8 grid grid-cols-1 gap-8 lg:grid-cols-3">
               <!-- Binaural Beats -->
               <div>
-                <h5 class="mb-4 text-lg font-medium text-gray-900">{{ $t("soundTherapy.interface.binauralBeats") }}</h5>
+                <h5 class="mb-4 text-lg font-medium text-gray-900 dark:text-gray-200">{{ $t("soundTherapy.interface.binauralBeats") }}</h5>
                 <div class="space-y-2">
                   <button
                     v-for="beat in binauralBeats"
@@ -51,19 +51,19 @@
                     :class="[
                       'w-full border p-3 text-left text-sm transition-all duration-200 hover:border-green-300',
                       selectedBeat === beat.value
-                        ? 'border-green-500 bg-green-50'
-                        : 'border-gray-200 bg-white',
+                        ? 'border-green-500 bg-green-50 dark:bg-green-900/20 dark:border-green-500/50'
+                        : 'border-gray-200 bg-white dark:bg-slate-700/20 dark:border-slate-600',
                     ]"
                   >
-                    <div class="font-medium text-gray-900">{{ $t(`soundTherapy.binauralBeats.${beat.index}.name`) }}</div>
-                    <div class="mt-1 text-xs text-gray-500">{{ $t(`soundTherapy.binauralBeats.${beat.index}.description`) }}</div>
+                    <div class="font-medium text-gray-900 dark:text-gray-200">{{ $t(`soundTherapy.binauralBeats.${beat.index}.name`) }}</div>
+                    <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ $t(`soundTherapy.binauralBeats.${beat.index}.description`) }}</div>
                   </button>
                 </div>
               </div>
 
               <!-- Modulation -->
               <div>
-                <h5 class="mb-4 text-lg font-medium text-gray-900">{{ $t("soundTherapy.interface.modulation") }}</h5>
+                <h5 class="mb-4 text-lg font-medium text-gray-900 dark:text-gray-200">{{ $t("soundTherapy.interface.modulation") }}</h5>
                 <div class="space-y-2">
                   <button
                     v-for="preset in lfoPresets"
@@ -72,31 +72,31 @@
                     :class="[
                       'w-full border p-3 text-left text-sm transition-all duration-200 hover:border-blue-300',
                       selectedLfoPreset?.index === preset.index
-                        ? 'border-blue-500 bg-blue-50'
-                        : 'border-gray-200 bg-white',
+                        ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20 dark:border-blue-500/50'
+                        : 'border-gray-200 bg-white dark:bg-slate-700/20 dark:border-slate-600',
                     ]"
                   >
-                    <div class="font-medium text-gray-900">{{ $t(`soundTherapy.modulation.${preset.index}.name`) }}</div>
-                    <div class="mt-1 text-xs text-gray-500">{{ $t(`soundTherapy.modulation.${preset.index}.description`) }}</div>
+                    <div class="font-medium text-gray-900 dark:text-gray-200">{{ $t(`soundTherapy.modulation.${preset.index}.name`) }}</div>
+                    <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ $t(`soundTherapy.modulation.${preset.index}.description`) }}</div>
                   </button>
                 </div>
               </div>
 
               <!-- Volume -->
               <div>
-                <h5 class="mb-4 text-lg font-medium text-gray-900">{{ $t("soundTherapy.interface.volume") }}</h5>
-                <div class="border border-gray-200 bg-gray-50 p-4">
+                <h5 class="mb-4 text-lg font-medium text-gray-900 dark:text-gray-200">{{ $t("soundTherapy.interface.volume") }}</h5>
+                <div class="border border-gray-200 bg-gray-50 p-4 dark:bg-slate-700/20 dark:border-slate-600">
                   <div class="flex items-center gap-4">
-                    <Icon name="ph:speaker-high" class="flex-shrink-0 text-gray-500" />
+                    <Icon name="ph:speaker-high" class="flex-shrink-0 text-gray-500 dark:text-gray-400" />
                     <div class="flex-1">
                       <input
                         type="range"
                         min="0"
                         max="100"
                         v-model="volume"
-                        class="slider h-2 w-full cursor-pointer appearance-none bg-gray-300"
+                        class="slider h-2 w-full cursor-pointer appearance-none bg-gray-300 dark:bg-slate-600"
                       />
-                      <div class="mt-2 flex justify-between text-xs text-gray-500">
+                      <div class="mt-2 flex justify-between text-xs text-gray-500 dark:text-gray-400">
                         <span>0%</span>
                         <span class="font-medium">{{ volume }}%</span>
                         <span>100%</span>
@@ -121,15 +121,15 @@
           </div>
 
           <!-- Playing State -->
-          <div v-if="isPlaying" class="mb-6 border border-purple-200 bg-purple-50 p-8 text-center">
+          <div v-if="isPlaying" class="mb-6 border border-purple-200 bg-purple-50 p-8 text-center dark:bg-purple-900/10 dark:border-purple-500/20">
             <div class="mb-6">
-              <h4 class="mb-2 text-2xl font-light text-gray-900">
+              <h4 class="mb-2 text-2xl font-light text-gray-900 dark:text-gray-200">
                 {{ $t(`soundTherapy.frequencies.${selectedFrequency.index}.name`) }} - {{ $t(`soundTherapy.frequencies.${selectedFrequency.index}.description`) }}
               </h4>
-              <p class="mb-4 text-purple-700">
+              <p class="mb-4 text-purple-700 dark:text-purple-400">
                 {{ $t("soundTherapy.playingState.description") }}
               </p>
-              <p class="text-base opacity-90">
+              <p class="text-base opacity-90 dark:text-gray-400">
                 {{ $t("soundTherapy.playingState.instructions") }}
               </p>
             </div>
@@ -141,68 +141,68 @@
     <!-- Educational Content -->
     <section class="mt-12 space-y-8">
       <!-- How It Works -->
-      <div class="border border-gray-200 bg-white/60 p-6">
+      <div class="border border-gray-200 bg-white/60 p-6 dark:bg-slate-800/20 dark:border-slate-700">
         <SectionHeader icon="ph:waveform" color="purple">
           {{ $t("soundTherapy.howItWorks.title") }}
         </SectionHeader>
-        <p class="mb-4 text-sm leading-relaxed text-gray-700">{{ $t("soundTherapy.howItWorks.description") }}</p>
+        <p class="mb-4 text-sm leading-relaxed text-gray-700 dark:text-gray-400">{{ $t("soundTherapy.howItWorks.description") }}</p>
         
         <div class="grid gap-4 md:grid-cols-2">
-          <div class="border border-gray-200 bg-white/60 p-4">
-            <h3 class="mb-2 font-semibold text-gray-800">{{ $t("soundTherapy.howItWorks.frequencies.title") }}</h3>
-            <p class="text-sm text-gray-600">{{ $t("soundTherapy.howItWorks.frequencies.description") }}</p>
+          <div class="border border-gray-200 bg-white/60 p-4 dark:bg-slate-700/20 dark:border-slate-600">
+            <h3 class="mb-2 font-semibold text-gray-800 dark:text-gray-200">{{ $t("soundTherapy.howItWorks.frequencies.title") }}</h3>
+            <p class="text-sm text-gray-600 dark:text-gray-400">{{ $t("soundTherapy.howItWorks.frequencies.description") }}</p>
           </div>
-          <div class="border border-gray-200 bg-white/60 p-4">
-            <h3 class="mb-2 font-semibold text-gray-800">{{ $t("soundTherapy.howItWorks.binaural.title") }}</h3>
-            <p class="text-sm text-gray-600">{{ $t("soundTherapy.howItWorks.binaural.description") }}</p>
+          <div class="border border-gray-200 bg-white/60 p-4 dark:bg-slate-700/20 dark:border-slate-600">
+            <h3 class="mb-2 font-semibold text-gray-800 dark:text-gray-200">{{ $t("soundTherapy.howItWorks.binaural.title") }}</h3>
+            <p class="text-sm text-gray-600 dark:text-gray-400">{{ $t("soundTherapy.howItWorks.binaural.description") }}</p>
           </div>
         </div>
       </div>
 
       <!-- Scientific Background -->
-      <div class="border border-gray-200 bg-white/60 p-6">
+      <div class="border border-gray-200 bg-white/60 p-6 dark:bg-slate-800/20 dark:border-slate-700">
         <SectionHeader icon="ph:flask" color="purple">
           {{ $t("soundTherapy.science.title") }}
         </SectionHeader>
         
         <div class="mb-4">
-          <p class="text-sm leading-relaxed text-gray-700" v-html="$t('soundTherapy.science.description')"></p>
+          <p class="text-sm leading-relaxed text-gray-700 dark:text-gray-400" v-html="$t('soundTherapy.science.description')"></p>
         </div>
 
         <div class="grid gap-4 md:grid-cols-3">
-          <div class="border border-purple-200 bg-purple-50 p-4">
+          <div class="border border-purple-200 bg-purple-50 p-4 dark:bg-purple-900/10 dark:border-purple-500/20">
             <div class="mb-2 flex items-center">
               <Icon name="ph:hospital" class="mr-2 text-purple-600" />
-              <span class="text-sm font-medium text-gray-800">{{ $t("soundTherapy.science.research.clinical.title") }}</span>
+              <span class="text-sm font-medium text-gray-800 dark:text-gray-200">{{ $t("soundTherapy.science.research.clinical.title") }}</span>
             </div>
-            <p class="text-xs text-gray-600" v-html="$t('soundTherapy.science.research.clinical.description')"></p>
+            <p class="text-xs text-gray-600 dark:text-gray-400" v-html="$t('soundTherapy.science.research.clinical.description')"></p>
           </div>
           
-          <div class="border border-purple-200 bg-purple-50 p-4">
+          <div class="border border-purple-200 bg-purple-50 p-4 dark:bg-purple-900/10 dark:border-purple-500/20">
             <div class="mb-2 flex items-center">
               <Icon name="ph:wave-sine" class="mr-2 text-purple-600" />
-              <span class="text-sm font-medium text-gray-800">{{ $t("soundTherapy.science.research.frequency.title") }}</span>
+              <span class="text-sm font-medium text-gray-800 dark:text-gray-200">{{ $t("soundTherapy.science.research.frequency.title") }}</span>
             </div>
-            <p class="text-xs text-gray-600" v-html="$t('soundTherapy.science.research.frequency.description')"></p>
+            <p class="text-xs text-gray-600 dark:text-gray-400" v-html="$t('soundTherapy.science.research.frequency.description')"></p>
           </div>
           
-          <div class="border border-purple-200 bg-purple-50 p-4">
+          <div class="border border-purple-200 bg-purple-50 p-4 dark:bg-purple-900/10 dark:border-purple-500/20">
             <div class="mb-2 flex items-center">
               <Icon name="ph:music-notes" class="mr-2 text-purple-600" />
-              <span class="text-sm font-medium text-gray-800">{{ $t("soundTherapy.science.research.combined.title") }}</span>
+              <span class="text-sm font-medium text-gray-800 dark:text-gray-200">{{ $t("soundTherapy.science.research.combined.title") }}</span>
             </div>
-            <p class="text-xs text-gray-600" v-html="$t('soundTherapy.science.research.combined.description')"></p>
+            <p class="text-xs text-gray-600 dark:text-gray-400" v-html="$t('soundTherapy.science.research.combined.description')"></p>
           </div>
         </div>
       </div>
 
       <div class="grid gap-8 md:grid-cols-2">
         <!-- When to Use -->
-        <div class="border border-gray-200 bg-white/60 p-6">
+        <div class="border border-gray-200 bg-white/60 p-6 dark:bg-slate-800/20 dark:border-slate-700">
           <SectionHeader icon="ph:calendar-check" color="blue">
             {{ $t("soundTherapy.whenToPractice.title") }}
           </SectionHeader>
-          <ul class="space-y-3 text-sm text-gray-700">
+          <ul class="space-y-3 text-sm text-gray-700 dark:text-gray-400">
             <li class="flex items-start">
               <Icon name="ph:flower-lotus-duotone" class="mr-2 mt-0.5 flex-shrink-0 text-purple-500" />
               <span>{{ $t("soundTherapy.whenToPractice.items.0") }}</span>
@@ -227,11 +227,11 @@
         </div>
 
         <!-- What You'll Experience -->
-        <div class="border border-gray-200 bg-white/60 p-6">
+        <div class="border border-gray-200 bg-white/60 p-6 dark:bg-slate-800/20 dark:border-slate-700">
           <SectionHeader icon="ph:trend-up" color="green">
             {{ $t("soundTherapy.whatYoullNotice.title") }}
           </SectionHeader>
-          <ul class="space-y-3 text-sm text-gray-700">
+          <ul class="space-y-3 text-sm text-gray-700 dark:text-gray-400">
             <li class="flex items-start">
               <Icon name="ph:waves" class="mr-2 mt-0.5 flex-shrink-0 text-purple-400" />
               <span>{{ $t("soundTherapy.whatYoullNotice.items.0") }}</span>
@@ -257,23 +257,23 @@
       </div>
 
       <!-- Tips Section -->
-      <div class="border border-indigo-200 bg-indigo-50 p-6">
+      <div class="border border-indigo-200 bg-indigo-50 p-6 dark:bg-indigo-900/10 dark:border-indigo-500/20">
         <div class="mb-4 text-center">
           <Icon name="ph:lightbulb" class="mx-auto mb-2 text-2xl text-indigo-600" />
-          <h2 class="font-semibold text-gray-800">{{ $t("soundTherapy.tips.title") }}</h2>
+          <h2 class="font-semibold text-gray-800 dark:text-gray-200">{{ $t("soundTherapy.tips.title") }}</h2>
         </div>
         <div class="grid gap-4 text-sm md:grid-cols-3">
           <div class="text-center">
-            <div class="mb-1 font-medium text-indigo-600">{{ $t("soundTherapy.tips.headphones.title") }}</div>
-            <p class="text-gray-600">{{ $t("soundTherapy.tips.headphones.description") }}</p>
+            <div class="mb-1 font-medium text-indigo-600 dark:text-indigo-400">{{ $t("soundTherapy.tips.headphones.title") }}</div>
+            <p class="text-gray-600 dark:text-gray-400">{{ $t("soundTherapy.tips.headphones.description") }}</p>
           </div>
           <div class="text-center">
-            <div class="mb-1 font-medium text-indigo-600">{{ $t("soundTherapy.tips.volume.title") }}</div>
-            <p class="text-gray-600">{{ $t("soundTherapy.tips.volume.description") }}</p>
+            <div class="mb-1 font-medium text-indigo-600 dark:text-indigo-400">{{ $t("soundTherapy.tips.volume.title") }}</div>
+            <p class="text-gray-600 dark:text-gray-400">{{ $t("soundTherapy.tips.volume.description") }}</p>
           </div>
           <div class="text-center">
-            <div class="mb-1 font-medium text-indigo-600">{{ $t("soundTherapy.tips.consistency.title") }}</div>
-            <p class="text-gray-600">{{ $t("soundTherapy.tips.consistency.description") }}</p>
+            <div class="mb-1 font-medium text-indigo-600 dark:text-indigo-400">{{ $t("soundTherapy.tips.consistency.title") }}</div>
+            <p class="text-gray-600 dark:text-gray-400">{{ $t("soundTherapy.tips.consistency.description") }}</p>
           </div>
         </div>
       </div>

--- a/pages/stress-relief-bubbles.vue
+++ b/pages/stress-relief-bubbles.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-gradient-to-br from-teal-50 via-cyan-50 to-blue-50 py-8">
+  <div class="min-h-screen bg-gradient-to-br from-teal-50 via-cyan-50 to-blue-50 py-8 dark:from-slate-800 dark:via-slate-900 dark:to-black">
     <Breadcrumb duration="2-5 min" />
 
     <section class="sektion">
@@ -8,13 +8,13 @@
           <div class="mb-6">
             <Icon name="ph:circles-four-fill" class="mx-auto text-6xl text-teal-600" />
           </div>
-          <h1 class="ptitle">{{ $t("techniques.stressReliefBubbles.name") }}</h1>
-          <p class="mx-auto mb-6 max-w-2xl leading-relaxed text-gray-600">
+          <h1 class="ptitle dark:text-gray-200">{{ $t("techniques.stressReliefBubbles.name") }}</h1>
+          <p class="mx-auto mb-6 max-w-2xl leading-relaxed text-gray-600 dark:text-gray-400">
             {{ $t("techniques.stressReliefBubbles.description") }}
           </p>
 
           <div class="mb-8 flex flex-col items-center justify-center">
-            <div class="mb-6 border border-gray-200 bg-white p-6 md:p-8">
+            <div class="mb-6 border border-gray-200 bg-white p-6 md:p-8 dark:bg-slate-800/20 dark:border-slate-700">
               <div class="bubble-container">
                 <div class="bubble-grid">
                   <div
@@ -42,55 +42,55 @@
     </section>
 
     <section class="mt-12 space-y-8">
-      <div class="rounded-md border border-gray-200 bg-white/60 p-6 shadow-sm">
+      <div class="rounded-md border border-gray-200 bg-white/60 p-6 shadow-sm dark:bg-slate-800/20 dark:border-slate-700">
         <SectionHeader icon="ph:hand-pointing" color="gray">
           {{ $t("stressReliefBubbles.howItWorks.title") }}
         </SectionHeader>
-        <p class="text-sm leading-relaxed text-gray-700">{{ $t("stressReliefBubbles.howItWorks.description") }}</p>
+        <p class="text-sm leading-relaxed text-gray-700 dark:text-gray-400">{{ $t("stressReliefBubbles.howItWorks.description") }}</p>
       </div>
 
-      <div class="rounded-md border border-gray-200 bg-white/60 p-6 shadow-sm">
+      <div class="rounded-md border border-gray-200 bg-white/60 p-6 shadow-sm dark:bg-slate-800/20 dark:border-slate-700">
         <SectionHeader icon="ph:flask" color="purple">
           {{ $t("stressReliefBubbles.science.title") }}
         </SectionHeader>
 
         <div class="mb-4">
-          <p class="text-sm leading-relaxed text-gray-700">{{ $t("stressReliefBubbles.science.description") }}</p>
+          <p class="text-sm leading-relaxed text-gray-700 dark:text-gray-400">{{ $t("stressReliefBubbles.science.description") }}</p>
         </div>
 
         <div class="grid gap-4 md:grid-cols-3">
-          <div class="rounded-md border border-purple-200 bg-purple-50 p-4">
+          <div class="rounded-md border border-purple-200 bg-purple-50 p-4 dark:bg-purple-900/10 dark:border-purple-500/20">
             <div class="mb-2 flex items-center">
               <Icon name="ph:waves" class="mr-2 text-purple-600" />
-              <span class="text-sm font-medium text-gray-800">{{ $t("stressReliefBubbles.science.research.sensory.title") }}</span>
+              <span class="text-sm font-medium text-gray-800 dark:text-gray-200">{{ $t("stressReliefBubbles.science.research.sensory.title") }}</span>
             </div>
-            <p class="text-xs text-gray-600">{{ $t("stressReliefBubbles.science.research.sensory.description") }}</p>
+            <p class="text-xs text-gray-600 dark:text-gray-400">{{ $t("stressReliefBubbles.science.research.sensory.description") }}</p>
           </div>
 
-          <div class="rounded-md border border-purple-200 bg-purple-50 p-4">
+          <div class="rounded-md border border-purple-200 bg-purple-50 p-4 dark:bg-purple-900/10 dark:border-purple-500/20">
             <div class="mb-2 flex items-center">
               <Icon name="ph:eye" class="mr-2 text-purple-600" />
-              <span class="text-sm font-medium text-gray-800">{{ $t("stressReliefBubbles.science.research.attention.title") }}</span>
+              <span class="text-sm font-medium text-gray-800 dark:text-gray-200">{{ $t("stressReliefBubbles.science.research.attention.title") }}</span>
             </div>
-            <p class="text-xs text-gray-600">{{ $t("stressReliefBubbles.science.research.attention.description") }}</p>
+            <p class="text-xs text-gray-600 dark:text-gray-400">{{ $t("stressReliefBubbles.science.research.attention.description") }}</p>
           </div>
 
-          <div class="rounded-md border border-purple-200 bg-purple-50 p-4">
+          <div class="rounded-md border border-purple-200 bg-purple-50 p-4 dark:bg-purple-900/10 dark:border-purple-500/20">
             <div class="mb-2 flex items-center">
               <Icon name="ph:hand" class="mr-2 text-purple-600" />
-              <span class="text-sm font-medium text-gray-800">{{ $t("stressReliefBubbles.science.research.motor.title") }}</span>
+              <span class="text-sm font-medium text-gray-800 dark:text-gray-200">{{ $t("stressReliefBubbles.science.research.motor.title") }}</span>
             </div>
-            <p class="text-xs text-gray-600">{{ $t("stressReliefBubbles.science.research.motor.description") }}</p>
+            <p class="text-xs text-gray-600 dark:text-gray-400">{{ $t("stressReliefBubbles.science.research.motor.description") }}</p>
           </div>
         </div>
       </div>
 
       <div class="grid gap-8 md:grid-cols-2">
-        <div class="rounded-md border border-gray-200 bg-white/60 p-6 shadow-sm">
+        <div class="rounded-md border border-gray-200 bg-white/60 p-6 shadow-sm dark:bg-slate-800/20 dark:border-slate-700">
           <SectionHeader icon="ph:calendar-check" color="blue">
             {{ $t("stressReliefBubbles.whenToPractice.title") }}
           </SectionHeader>
-          <ul class="space-y-3 text-sm text-gray-700">
+          <ul class="space-y-3 text-sm text-gray-700 dark:text-gray-400">
             <li class="flex items-start">
               <Icon name="ph:lightning-slash" class="mr-2 mt-0.5 flex-shrink-0 text-teal-500" />
               <span>{{ $t("stressReliefBubbles.whenToPractice.items.0") }}</span>
@@ -110,11 +110,11 @@
           </ul>
         </div>
 
-        <div class="rounded-md border border-gray-200 bg-white/60 p-6 shadow-sm">
+        <div class="rounded-md border border-gray-200 bg-white/60 p-6 shadow-sm dark:bg-slate-800/20 dark:border-slate-700">
           <SectionHeader icon="ph:trend-up" color="green">
             {{ $t("stressReliefBubbles.whatYoullNotice.title") }}
           </SectionHeader>
-          <ul class="space-y-3 text-sm text-gray-700">
+          <ul class="space-y-3 text-sm text-gray-700 dark:text-gray-400">
             <li class="flex items-start">
               <Icon name="ph:hand-peace" class="mr-2 mt-0.5 flex-shrink-0 text-teal-400" />
               <span>{{ $t("stressReliefBubbles.whatYoullNotice.items.0") }}</span>
@@ -135,23 +135,23 @@
         </div>
       </div>
 
-      <div class="rounded-md border border-indigo-200 bg-indigo-50 p-6 shadow-sm">
+      <div class="rounded-md border border-indigo-200 bg-indigo-50 p-6 shadow-sm dark:bg-indigo-900/10 dark:border-indigo-500/20">
         <div class="mb-4 text-center">
           <Icon name="ph:lightbulb" class="mx-auto mb-2 text-2xl text-indigo-600" />
-          <h2 class="font-semibold text-gray-800">{{ $t("stressReliefBubbles.tips.title") }}</h2>
+          <h2 class="font-semibold text-gray-800 dark:text-gray-200">{{ $t("stressReliefBubbles.tips.title") }}</h2>
         </div>
         <div class="grid gap-4 text-sm md:grid-cols-3">
           <div class="text-center">
-            <div class="mb-1 font-medium text-indigo-600">{{ $t("stressReliefBubbles.tips.mindful.title") }}</div>
-            <p class="text-gray-600">{{ $t("stressReliefBubbles.tips.mindful.description") }}</p>
+            <div class="mb-1 font-medium text-indigo-600 dark:text-indigo-400">{{ $t("stressReliefBubbles.tips.mindful.title") }}</div>
+            <p class="text-gray-600 dark:text-gray-400">{{ $t("stressReliefBubbles.tips.mindful.description") }}</p>
           </div>
           <div class="text-center">
-            <div class="mb-1 font-medium text-indigo-600">{{ $t("stressReliefBubbles.tips.breaks.title") }}</div>
-            <p class="text-gray-600">{{ $t("stressReliefBubbles.tips.breaks.description") }}</p>
+            <div class="mb-1 font-medium text-indigo-600 dark:text-indigo-400">{{ $t("stressReliefBubbles.tips.breaks.title") }}</div>
+            <p class="text-gray-600 dark:text-gray-400">{{ $t("stressReliefBubbles.tips.breaks.description") }}</p>
           </div>
           <div class="text-center">
-            <div class="mb-1 font-medium text-indigo-600">{{ $t("stressReliefBubbles.tips.environment.title") }}</div>
-            <p class="text-gray-600">{{ $t("stressReliefBubbles.tips.environment.description") }}</p>
+            <div class="mb-1 font-medium text-indigo-600 dark:text-indigo-400">{{ $t("stressReliefBubbles.tips.environment.title") }}</div>
+            <p class="text-gray-600 dark:text-gray-400">{{ $t("stressReliefBubbles.tips.environment.description") }}</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This commit introduces dark mode to the application.

Key changes:
- Installed and configured the `@nuxtjs/color-mode` module to handle theme switching.
- Added a theme switcher button to the application header, allowing users to choose between light, dark, and system themes.
- Updated the styling for numerous pages and components to support dark mode. This includes adjusting background colors, text colors, border colors, and other styles to ensure readability and a consistent user experience in dark mode.

Updated pages:
- pages/index.vue
- pages/breathing.vue
- pages/grounding.vue
- pages/guided-breathing.vue
- pages/peaceful-visualization.vue
- pages/progressive-muscle-relaxation.vue
- pages/sound-therapy.vue
- pages/stress-relief-bubbles.vue

Updated components:
- components/AppHeader.vue
- components/RelatedTechniques.vue
- components/SectionHeader.vue

The remaining page, `pages/thought-labeling.vue`, has not yet been updated with dark mode styles.